### PR TITLE
Different approach on arrays

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -27,7 +27,6 @@
 #define PLORTH_CONTEXT_HPP_GUARD
 
 #include <plorth/runtime.hpp>
-#include <plorth/value-array.hpp>
 #include <plorth/value-error.hpp>
 
 #include <deque>
@@ -216,7 +215,7 @@ namespace plorth
      * Constructs array from given sequence of values and pushes it into the
      * data stack.
      */
-    void push_array(const array::container_type& elements);
+    void push_array(array::const_pointer elements, array::size_type size);
 
     /**
      * Constructs object from given properties and pushes it into the data

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -26,6 +26,7 @@
 #ifndef PLORTH_RUNTIME_HPP_GUARD
 #define PLORTH_RUNTIME_HPP_GUARD
 
+#include <plorth/value-array.hpp>
 #include <plorth/value-boolean.hpp>
 #include <plorth/value-object.hpp>
 #include <plorth/value-quote.hpp>
@@ -110,6 +111,15 @@ namespace plorth
      *             whether some kind of error was occurred.
      */
     bool import(const ref<context>& ctx, const unistring& path);
+
+    /**
+     * Constructs array value from given elements.
+     *
+     * \param elements Array of elements to construct array from.
+     * \param size     Number of elements in the array.
+     * \return         Reference to the created array value.
+     */
+    ref<class array> array(array::const_pointer elements, array::size_type size);
 
     /**
      * Constructs compiled quote from given sequence of tokens.

--- a/include/plorth/value-array.hpp
+++ b/include/plorth/value-array.hpp
@@ -28,8 +28,6 @@
 
 #include <plorth/value.hpp>
 
-#include <vector>
-
 namespace plorth
 {
   /**
@@ -39,21 +37,16 @@ namespace plorth
   class array : public value
   {
   public:
-    using container_type = std::vector<ref<value>>;
+    using size_type = std::size_t;
+    using value_type = ref<value>;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
 
-    /**
-     * Constructs new array from given elements.
-     */
-    explicit array(const container_type& elements);
+    virtual size_type size() const = 0;
 
-    /**
-     * Returns reference to the underlying container that contains the elements
-     * of the array.
-     */
-    inline const container_type& elements() const
-    {
-      return m_elements;
-    }
+    virtual const_reference at(size_type offset) const = 0;
 
     inline enum type type() const
     {
@@ -63,10 +56,6 @@ namespace plorth
     bool equals(const ref<value>& that) const;
     unistring to_string () const;
     unistring to_source() const;
-
-  private:
-    /** Container for elements of the array. */
-    const container_type m_elements;
   };
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -149,9 +149,9 @@ namespace plorth
     push(m_runtime->value<string>(value));
   }
 
-  void context::push_array(const array::container_type& elements)
+  void context::push_array(array::const_pointer elements, array::size_type size)
   {
-    push(m_runtime->value<array>(elements));
+    push(m_runtime->array(elements, size));
   }
 
   void context::push_object(const object::container_type& properties)

--- a/src/value-object.cpp
+++ b/src/value-object.cpp
@@ -174,7 +174,7 @@ namespace plorth
     }
 
     ctx->push(obj);
-    ctx->push_array(result);
+    ctx->push_array(result.data(), result.size());
   }
 
   /**
@@ -207,7 +207,7 @@ namespace plorth
     }
 
     ctx->push(obj);
-    ctx->push_array(result);
+    ctx->push_array(result.data(), result.size());
   }
 
   /**

--- a/src/value-quote.cpp
+++ b/src/value-quote.cpp
@@ -481,7 +481,7 @@ namespace plorth
                                 std::vector<token>::const_iterator& it,
                                 const std::vector<token>::const_iterator& end)
   {
-    array::container_type elements;
+    std::vector<ref<value>> elements;
     ref<value> val;
 
     for (;;)
@@ -523,7 +523,7 @@ namespace plorth
       }
     }
 
-    return ctx->runtime()->value<array>(elements);
+    return ctx->runtime()->array(elements.data(), elements.size());
   }
 
   static ref<object> parse_object(const ref<context>& ctx,

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -227,7 +227,7 @@ namespace plorth
     {
       const unistring& input = str->value();
       const auto length = input.length();
-      array::container_type output;
+      std::vector<ref<value>> output;
 
       output.reserve(length);
       for (std::size_t i = 0; i < length; ++i)
@@ -235,7 +235,7 @@ namespace plorth
         output.push_back(runtime->value<string>(input.substr(i, 1)));
       }
       ctx->push(str);
-      ctx->push_array(output);
+      ctx->push_array(output.data(), output.size());
     }
   }
 
@@ -270,7 +270,7 @@ namespace plorth
     }
 
     ctx->push(str);
-    ctx->push_array(result);
+    ctx->push_array(result.data(), result.size());
   }
 
   /**
@@ -319,7 +319,7 @@ namespace plorth
       }
 
       ctx->push(str);
-      ctx->push_array(result);
+      ctx->push_array(result.data(), result.size());
     }
   }
 
@@ -370,7 +370,7 @@ namespace plorth
       }
 
       ctx->push(str);
-      ctx->push_array(result);
+      ctx->push_array(result.data(), result.size());
     }
   }
 


### PR DESCRIPTION
Instead of always relying on arrays which are only wrappers to std::vector,
introduce abstract array class with multiple different implementations on it.

This in theory could reduce memory usage and binary size, especially with
scripts that combine arrays with each other. Somewhat experimental idea that
could be expanded also to string values.