### PR TITLE
Bring back integer numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ OPTION(
 )
 
 OPTION(
+  PLORTH_ENABLE_INTEGER_CACHE
+  "Whether commonly used integer numbers should be cached or not."
+  ON
+)
+
+OPTION(
   PLORTH_ENABLE_MEMORY_POOL
   "Enable if you want the interpreter to use memory pools."
   ON

--- a/include/plorth/config.hpp.in
+++ b/include/plorth/config.hpp.in
@@ -30,6 +30,7 @@
 
 // Optional features.
 #cmakedefine PLORTH_ENABLE_MODULES 1
+#cmakedefine PLORTH_ENABLE_INTEGER_CACHE 1
 #cmakedefine PLORTH_ENABLE_MEMORY_POOL 1
 #cmakedefine PLORTH_ENABLE_GC_DEBUG 1
 

--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -202,9 +202,20 @@ namespace plorth
     void push_boolean(bool value);
 
     /**
-     * Pushes number value into the data stack.
+     * Pushes integer number value into the data stack.
      */
-    void push_number(double value);
+    void push_int(std::int64_t value);
+
+    /**
+     * Pushes real number value into the data stack.
+     */
+    void push_real(double value);
+
+    /**
+     * Pushes either integer or real number into stack, based on the given text
+     * input which is parsed into a number.
+     */
+    void push_number(const unistring& value);
 
     /**
      * Pushes string value into the data stack.
@@ -291,7 +302,7 @@ namespace plorth
      * \return     Boolean flag that tells whether the operation was
      *             successfull or not.
      */
-    bool pop_number(double& slot);
+    bool pop_number(ref<number>& slot);
 
     /**
      * Pops string value from the data stack and places it into given slot. If

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -28,6 +28,7 @@
 
 #include <plorth/value-array.hpp>
 #include <plorth/value-boolean.hpp>
+#include <plorth/value-number.hpp>
 #include <plorth/value-object.hpp>
 #include <plorth/value-quote.hpp>
 #include <plorth/value-string.hpp>
@@ -336,6 +337,10 @@ namespace plorth
     std::vector<unistring> m_module_paths;
     /** Container for already imported modules. */
     object::container_type m_imported_modules;
+#if PLORTH_ENABLE_INTEGER_CACHE
+    /** Cache for commonly used integer numbers. */
+    ref<class number> m_integer_cache[256];
+#endif
   };
 }
 

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -132,6 +132,31 @@ namespace plorth
     bool import(const ref<context>& ctx, const unistring& path);
 
     /**
+     * Constructs integer number from given value.
+     *
+     * \param value Value of the number.
+     * \return      Reference to the created number value.
+     */
+    ref<class number> number(std::int64_t value);
+
+    /**
+     * Constructs real number from given value.
+     *
+     * \param value Value of the number.
+     * \return      Reference to the created number value.
+     */
+    ref<class number> number(double value);
+
+    /**
+     * Parses given text input into number (either real or integer) and
+     * constructs number value from it.
+     *
+     * \param value Value of the number as text.
+     * \return      Reference to the created number value.
+     */
+    ref<class number> number(const unistring& value);
+
+    /**
      * Constructs array value from given elements.
      *
      * \param elements Array of elements to construct array from.

--- a/include/plorth/value-number.hpp
+++ b/include/plorth/value-number.hpp
@@ -33,12 +33,37 @@ namespace plorth
   class number : public value
   {
   public:
-    explicit number(double value);
-
-    inline double value() const
+    /**
+     * Enumeration for different supported number types.
+     */
+    enum number_type
     {
-      return m_value;
+      number_type_int,
+      number_type_real
+    };
+
+    /**
+     * Returns type of the number.
+     */
+    virtual enum number_type number_type() const = 0;
+
+    /**
+     * Tests whether this number is of specific type.
+     */
+    inline bool is(enum number_type t) const
+    {
+      return number_type() == t;
     }
+
+    /**
+     * Returns value of the number as integer.
+     */
+    virtual std::int64_t as_int() const = 0;
+
+    /**
+     * Returns value of the number as floating point decimal.
+     */
+    virtual double as_real() const = 0;
 
     inline enum type type() const
     {
@@ -48,9 +73,6 @@ namespace plorth
     bool equals(const ref<class value>& that) const;
     unistring to_string() const;
     unistring to_source() const;
-
-  private:
-    const double m_value;
   };
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -24,9 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
-#include <plorth/value-number.hpp>
-#include <plorth/value-quote.hpp>
-#include <plorth/value-string.hpp>
 
 #include "./utils.hpp"
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,17 +105,9 @@ namespace plorth
     // If the name of the word can be converted into number, then do just that.
     if (is_number(word))
     {
-      double num;
+      push_number(word);
 
-      if (to_number(word, num))
-      {
-        m_data.push_back(m_runtime->value<number>(num));
-
-        return true;
-      }
-      error(error::code_value, "Unable to parse `" + word + "' into number.");
-
-      return false;
+      return true;
     }
 
     // Otherwise it's reference error.
@@ -139,9 +131,19 @@ namespace plorth
     push(m_runtime->boolean(value));
   }
 
-  void context::push_number(double value)
+  void context::push_int(std::int64_t value)
   {
-    push(m_runtime->value<number>(value));
+    push(m_runtime->number(value));
+  }
+
+  void context::push_real(double value)
+  {
+    push(m_runtime->number(value));
+  }
+
+  void context::push_number(const unistring& value)
+  {
+    push(m_runtime->number(value));
   }
 
   void context::push_string(const unistring& value)
@@ -265,7 +267,7 @@ namespace plorth
     return true;
   }
 
-  bool context::pop_number(double& slot)
+  bool context::pop_number(ref<number>& slot)
   {
     ref<class value> value;
 
@@ -273,7 +275,7 @@ namespace plorth
     {
       return false;
     }
-    slot = value.cast<number>()->value();
+    slot = value.cast<number>();
 
     return true;
   }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -83,7 +83,7 @@ namespace plorth
    */
   static void w_e(const ref<context>& ctx)
   {
-    ctx->push_number(M_E);
+    ctx->push_real(M_E);
   }
 
   /**
@@ -96,7 +96,7 @@ namespace plorth
    */
   static void w_pi(const ref<context>& ctx)
   {
-    ctx->push_number(M_PI);
+    ctx->push_real(M_PI);
   }
 
   /**
@@ -126,7 +126,7 @@ namespace plorth
    */
   static void w_depth(const ref<context>& ctx)
   {
-    ctx->push_number(ctx->size());
+    ctx->push_int(ctx->size());
   }
 
   /**
@@ -1095,20 +1095,19 @@ namespace plorth
    */
   static void w_emit(const ref<context>& ctx)
   {
-    double number;
+    ref<number> num;
 
-    if (!ctx->pop_number(number))
+    if (ctx->pop_number(num))
     {
-      return;
-    }
+      std::int64_t c = num->as_int();
 
-    if (!unichar_validate(number))
-    {
-      ctx->error(error::code_range, "Invalid Unicode code point.");
-      return;
+      if (!unichar_validate(c))
+      {
+        ctx->error(error::code_range, "Invalid Unicode code point.");
+      } else {
+        std::cout << unistring(1, static_cast<unichar>(c));
+      }
     }
-
-    std::cout << unistring(1, number);
   }
 
   /**
@@ -1122,7 +1121,7 @@ namespace plorth
    */
   static void w_now(const ref<context>& ctx)
   {
-    ctx->push_number(std::time(nullptr));
+    ctx->push_int(std::time(nullptr));
   }
 
   /**

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -24,8 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
-#include <plorth/value-number.hpp>
-#include <plorth/value-string.hpp>
 
 #include <cmath>
 #include <ctime>

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -31,8 +31,10 @@
 namespace plorth
 {
   unistring json_stringify(const unistring&);
+  std::int64_t to_integer(const unistring&);
+  double to_real(const unistring&);
   bool is_number(const unistring&);
-  bool to_number(const unistring&, double&);
+  unistring to_unistring(std::int64_t);
   unistring to_unistring(double);
 }
 

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -24,8 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
-#include <plorth/value-number.hpp>
-#include <plorth/value-string.hpp>
 
 namespace plorth
 {

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
+#include <plorth/value-number.hpp>
 #include <plorth/value-string.hpp>
 
 namespace plorth
@@ -206,7 +207,7 @@ namespace plorth
     if (ctx->pop_array(ary))
     {
       ctx->push(ary);
-      ctx->push_number(ary->size());
+      ctx->push_int(ary->size());
     }
   }
 
@@ -276,7 +277,7 @@ namespace plorth
       {
         if (val == ary->at(i))
         {
-          ctx->push_number(i);
+          ctx->push_int(i);
           return;
         }
       }
@@ -363,7 +364,7 @@ namespace plorth
         }
         else if (result)
         {
-          ctx->push_number(i);
+          ctx->push_int(i);
           return;
         }
       }
@@ -803,29 +804,29 @@ namespace plorth
   static void w_repeat(const ref<context>& ctx)
   {
     ref<array> ary;
+    ref<number> num;
     double count;
 
-    if (ctx->pop_array(ary) && ctx->pop_number(count))
+    if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
-      std::vector<ref<value>> result;
+      const auto size = ary->size();
+      const std::int64_t count = num->as_int();
 
-      if (count < 0.0)
+      if (count >= 0)
       {
-        count = -count;
-      }
+        ref<value> result[size * count];
 
-      result.reserve(ary->size() * count);
-
-      while (count >= 1.0)
-      {
-        count -= 1.0;
-        for (array::size_type i = 0; i < ary->size(); ++i)
+        for (std::int64_t i = 0; i < count; ++i)
         {
-          result.push_back(ary->at(i));
+          for (array::size_type j = 0; j < size; ++j)
+          {
+            result[(i * size) + j] = ary->at(j);
+          }
         }
+        ctx->push_array(result, size * count);
+      } else {
+        ctx->error(error::code_range, "Invalid repeat count.");
       }
-
-      ctx->push_array(result.data(), result.size());
     }
   }
 
@@ -978,18 +979,20 @@ namespace plorth
   static void w_get(const ref<context>& ctx)
   {
     ref<array> ary;
-    double index;
+    ref<number> num;
 
-    if (ctx->pop_array(ary) && ctx->pop_number(index))
+    if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
-      if (index < 0.0)
+      std::int64_t index = num->as_int();
+
+      if (index < 0)
       {
         index += ary->size();
       }
 
       ctx->push(ary);
 
-      if (index < 0.0 || index > ary->size())
+      if (index < 0 || index > ary->size())
       {
         ctx->error(error::code_range, "Array index out of bounds.");
         return;
@@ -1018,24 +1021,26 @@ namespace plorth
   static void w_set(const ref<context>& ctx)
   {
     ref<array> ary;
-    double index;
+    ref<number> num;
     ref<value> val;
 
-    if (ctx->pop_array(ary) && ctx->pop_number(index) && ctx->pop(val))
+    if (ctx->pop_array(ary) && ctx->pop_number(num) && ctx->pop(val))
     {
+      const auto size = ary->size();
+      std::int64_t index = num->as_int();
       std::vector<ref<value>> result;
 
-      for (array::size_type i = 0;  i < ary->size(); ++i)
+      if (index < 0)
+      {
+        index += size;
+      }
+
+      for (array::size_type i = 0;  i < size; ++i)
       {
         result.push_back(ary->at(i));
       }
 
-      if (index < 0.0)
-      {
-        index += result.size();
-      }
-
-      if (index < 0.0 || index > result.size())
+      if (index < 0 || index > size)
       {
         result.push_back(val);
       } else {

--- a/src/value-error.cpp
+++ b/src/value-error.cpp
@@ -121,7 +121,7 @@ namespace plorth
     if (ctx->pop(err, value::type_error))
     {
       ctx->push(err);
-      ctx->push_number(err.cast<error>()->code());
+      ctx->push_int(err.cast<error>()->code());
     }
   }
 

--- a/src/value-number.cpp
+++ b/src/value-number.cpp
@@ -32,27 +32,122 @@
 
 namespace plorth
 {
-  number::number(double value)
-    : m_value(value) {}
+  namespace
+  {
+    class int_number : public number
+    {
+    public:
+      explicit int_number(std::int64_t val)
+        : m_value(val) {}
+
+      enum number_type number_type() const
+      {
+        return number_type_int;
+      }
+
+      std::int64_t as_int() const
+      {
+        return m_value;
+      }
+
+      double as_real() const
+      {
+        return static_cast<double>(m_value);
+      }
+
+    private:
+      const std::int64_t m_value;
+    };
+
+    class real_number : public number
+    {
+    public:
+      explicit real_number(double val)
+        : m_value(val) {}
+
+      enum number_type number_type() const
+      {
+        return number_type_real;
+      }
+
+      std::int64_t as_int() const
+      {
+        double value = m_value;
+
+        if (value > 0.0)
+        {
+          value = std::floor(value);
+        }
+        if (value < 0.0)
+        {
+          value = std::ceil(value);
+        }
+
+        return static_cast<std::int64_t>(value);
+      }
+
+      double as_real() const
+      {
+        return m_value;
+      }
+
+    private:
+      const double m_value;
+    };
+  }
 
   bool number::equals(const ref<class value>& that) const
   {
+    ref<number> num;
+
     if (!that || !that->is(type_number))
     {
       return false;
     }
-
-    return m_value == that.cast<number>()->m_value;
+    num = that.cast<number>();
+    if (is(number_type_real) || num->is(number_type_real))
+    {
+      return as_real() == num->as_real();
+    } else {
+      return as_int() == num->as_int();
+    }
   }
 
   unistring number::to_string() const
   {
-    return to_unistring(m_value);
+    if (is(number_type_real))
+    {
+      return to_unistring(as_real());
+    } else {
+      return to_unistring(as_int());
+    }
   }
 
   unistring number::to_source() const
   {
     return to_string();
+  }
+
+  ref<class number> runtime::number(std::int64_t value)
+  {
+    return new (*m_memory_manager) int_number(value);
+  }
+
+  ref<class number> runtime::number(double value)
+  {
+    return new (*m_memory_manager) real_number(value);
+  }
+
+  ref<class number> runtime::number(const unistring& value)
+  {
+    const auto dot_index = value.find('.');
+
+    if (dot_index == unistring::npos)
+    {
+      return number(to_integer(value));
+    } else {
+      return number(to_real(value));
+    }
   }
 
   /**
@@ -70,12 +165,17 @@ namespace plorth
    */
   static void w_is_nan(const ref<context>& ctx)
   {
-    ref<value> num;
+    ref<number> num;
 
-    if (ctx->pop(num, value::type_number))
+    if (ctx->pop_number(num))
     {
       ctx->push(num);
-      ctx->push_boolean(std::isnan(num.cast<number>()->value()));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_boolean(std::isnan(num->as_real()));
+      } else {
+        ctx->push_boolean(false);
+      }
     }
   }
 
@@ -94,12 +194,17 @@ namespace plorth
    */
   static void w_is_finite(const ref<context>& ctx)
   {
-    ref<value> num;
+    ref<number> num;
 
-    if (ctx->pop(num, value::type_number))
+    if (ctx->pop_number(num))
     {
       ctx->push(num);
-      ctx->push_boolean(std::isfinite(num.cast<number>()->value()));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_boolean(std::isfinite(num->as_real()));
+      } else {
+        ctx->push_boolean(true);
+      }
     }
   }
 
@@ -115,25 +220,24 @@ namespace plorth
    */
   static void w_times(const ref<context>& ctx)
   {
-    double count;
-    ref<class quote> quote;
+    ref<number> num;
+    ref<quote> quo;
 
-    if (!ctx->pop_number(count) || !ctx->pop_quote(quote))
+    if (ctx->pop_number(num) && ctx->pop_quote(quo))
     {
-      return;
-    }
+      std::int64_t count = num->as_int();
 
-    if (count < 0.0)
-    {
-      count = -count;
-    }
-
-    while (count >= 1.0)
-    {
-      count -= 1.0;
-      if (!quote->call(ctx))
+      if (count < 0)
       {
-        return;
+        count = -count;
+      }
+      while (count > 0)
+      {
+        --count;
+        if (!quo->call(ctx))
+        {
+          return;
+        }
       }
     }
   }
@@ -152,11 +256,16 @@ namespace plorth
    */
   static void w_abs(const ref<context>& ctx)
   {
-    double num;
+    ref<number> num;
 
     if (ctx->pop_number(num))
     {
-      ctx->push_number(std::abs(num));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_real(std::fabs(num->as_real()));
+      } else {
+        ctx->push_int(std::abs(num->as_int()));
+      }
     }
   }
 
@@ -174,11 +283,16 @@ namespace plorth
    */
   static void w_round(const ref<context>& ctx)
   {
-    double num;
+    ref<number> num;
 
     if (ctx->pop_number(num))
     {
-      ctx->push_number(std::round(num));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_int(std::round(num->as_real()));
+      } else {
+        ctx->push(num);
+      }
     }
   }
 
@@ -196,11 +310,16 @@ namespace plorth
    */
   static void w_ceil(const ref<context>& ctx)
   {
-    double num;
+    ref<number> num;
 
     if (ctx->pop_number(num))
     {
-      ctx->push_number(std::ceil(num));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_int(std::ceil(num->as_real()));
+      } else {
+        ctx->push(num);
+      }
     }
   }
 
@@ -218,11 +337,16 @@ namespace plorth
    */
   static void w_floor(const ref<context>& ctx)
   {
-    double num;
+    ref<number> num;
 
     if (ctx->pop_number(num))
     {
-      ctx->push_number(std::floor(num));
+      if (num->is(number::number_type_real))
+      {
+        ctx->push_int(std::floor(num->as_real()));
+      } else {
+        ctx->push(num);
+      }
     }
   }
 
@@ -241,12 +365,17 @@ namespace plorth
    */
   static void w_max(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b > a ? b : a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push(a->as_real() > b->as_real() ? a : b);
+      } else {
+        ctx->push(a->as_int() > b->as_int() ? a : b);
+      }
     }
   }
 
@@ -265,12 +394,17 @@ namespace plorth
    */
   static void w_min(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b < a ? b : a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push(a->as_real() < b->as_real() ? a : b);
+      } else {
+        ctx->push(a->as_int() < b->as_int() ? a : b);
+      }
     }
   }
 
@@ -290,21 +424,44 @@ namespace plorth
    */
   static void w_clamp(const ref<context>& ctx)
   {
-    double num;
-    double max;
-    double min;
+    ref<number> a;
+    ref<number> b;
+    ref<number> c;
 
-    if (ctx->pop_number(num) && ctx->pop_number(max) && ctx->pop_number(min))
+    if (ctx->pop_number(c) && ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (num > max)
+      if (a->is(number::number_type_real)
+          || b->is(number::number_type_real)
+          || c->is(number::number_type_real))
       {
-        num = max;
+        const double min = a->as_real();
+        const double max = b->as_real();
+        double number = c->as_real();
+
+        if (number > max)
+        {
+          number = max;
+        }
+        if (number < min)
+        {
+          number = min;
+        }
+        ctx->push_real(number);
+      } else {
+        const std::int64_t min = a->as_int();
+        const std::int64_t max = b->as_int();
+        std::int64_t number = c->as_int();
+
+        if (number > max)
+        {
+          number = max;
+        }
+        if (number < min)
+        {
+          number = min;
+        }
+        ctx->push_int(number);
       }
-      if (num < min)
-      {
-        num = min;
-      }
-      ctx->push_number(num);
     }
   }
 
@@ -325,13 +482,28 @@ namespace plorth
    */
   static void w_is_in_range(const ref<context>& ctx)
   {
-    double num;
-    double max;
-    double min;
+    ref<number> a;
+    ref<number> b;
+    ref<number> c;
 
-    if (ctx->pop_number(num) && ctx->pop_number(max) && ctx->pop_number(min))
+    if (ctx->pop_number(c) && ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_boolean(num >= min && num <= max);
+      if (a->is(number::number_type_real)
+          || b->is(number::number_type_real)
+          || c->is(number::number_type_real))
+      {
+        const double min = a->as_real();
+        const double max = b->as_real();
+        const double number = c->as_real();
+
+        ctx->push_boolean(number >= min && number <= max);
+      } else {
+        const std::int64_t min = a->as_int();
+        const std::int64_t max = b->as_int();
+        const std::int64_t number = c->as_int();
+
+        ctx->push_boolean(number >= min && number <= max);
+      }
     }
   }
 
@@ -350,12 +522,17 @@ namespace plorth
    */
   static void w_add(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b + a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_real(a->as_real() + b->as_real());
+      } else {
+        ctx->push_int(a->as_int() + b->as_int());
+      }
     }
   }
 
@@ -374,12 +551,17 @@ namespace plorth
    */
   static void w_sub(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b - a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_real(a->as_real() - b->as_real());
+      } else {
+        ctx->push_int(a->as_int() - b->as_int());
+      }
     }
   }
 
@@ -398,12 +580,17 @@ namespace plorth
    */
   static void w_mul(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b * a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_real(a->as_real() * b->as_real());
+      } else {
+        ctx->push_int(a->as_int() * b->as_int());
+      }
     }
   }
 
@@ -422,12 +609,25 @@ namespace plorth
    */
   static void w_div(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(b / a);
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_real(a->as_real() / b->as_real());
+      } else {
+        const std::int64_t x = a->as_int();
+        const std::int64_t y = a->as_int();
+
+        if (y == 0)
+        {
+          ctx->push_real(y < 0 ? -INFINITY : INFINITY);
+        } else {
+          ctx->push_int(x / y);
+        }
+      }
     }
   }
 
@@ -447,12 +647,25 @@ namespace plorth
    */
   static void w_mod(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_number(std::fmod(b, a));
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_real(std::fmod(a->as_real(), b->as_real()));
+      } else {
+        const std::int64_t x = a->as_int();
+        const std::int64_t y = a->as_int();
+
+        if (y == 0)
+        {
+          ctx->push_real(NAN);
+        } else {
+          ctx->push_int(x % y);
+        }
+      }
     }
   }
 
@@ -471,12 +684,20 @@ namespace plorth
    */
   static void w_lt(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_boolean(b < a);
+      const auto a_type = a->number_type();
+      const auto b_type = b->number_type();
+
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_boolean(a->as_real() < b->as_real());
+      } else {
+        ctx->push_boolean(a->as_int() < b->as_int());
+      }
     }
   }
 
@@ -495,12 +716,20 @@ namespace plorth
    */
   static void w_gt(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_boolean(b > a);
+      const auto a_type = a->number_type();
+      const auto b_type = b->number_type();
+
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_boolean(a->as_real() > b->as_real());
+      } else {
+        ctx->push_boolean(a->as_int() > b->as_int());
+      }
     }
   }
 
@@ -519,12 +748,20 @@ namespace plorth
    */
   static void w_lte(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_boolean(b <= a);
+      const auto a_type = a->number_type();
+      const auto b_type = b->number_type();
+
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_boolean(a->as_real() <= b->as_real());
+      } else {
+        ctx->push_boolean(a->as_int() <= b->as_int());
+      }
     }
   }
 
@@ -543,12 +780,20 @@ namespace plorth
    */
   static void w_gte(const ref<context>& ctx)
   {
-    double a;
-    double b;
+    ref<number> a;
+    ref<number> b;
 
-    if (ctx->pop_number(a) && ctx->pop_number(b))
+    if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      ctx->push_boolean(b >= a);
+      const auto a_type = a->number_type();
+      const auto b_type = b->number_type();
+
+      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      {
+        ctx->push_boolean(a->as_real() >= b->as_real());
+      } else {
+        ctx->push_boolean(a->as_int() >= b->as_int());
+      }
     }
   }
 

--- a/src/value-number.cpp
+++ b/src/value-number.cpp
@@ -24,7 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
-#include <plorth/value-number.hpp>
 
 #include "./utils.hpp"
 
@@ -130,6 +129,24 @@ namespace plorth
 
   ref<class number> runtime::number(std::int64_t value)
   {
+#if PLORTH_ENABLE_INTEGER_CACHE
+    static const int offset = 128;
+
+    if (value >= -128 && value <= 127)
+    {
+      const int index = value + offset;
+      auto reference = m_integer_cache[index];
+
+      if (!reference)
+      {
+        reference = new (*m_memory_manager) int_number(value);
+        m_integer_cache[index] = reference;
+      }
+
+      return reference;
+    }
+#endif
+
     return new (*m_memory_manager) int_number(value);
   }
 

--- a/src/value-quote.cpp
+++ b/src/value-quote.cpp
@@ -25,8 +25,6 @@
  */
 #include <plorth/context.hpp>
 #include <plorth/token.hpp>
-#include <plorth/value-number.hpp>
-#include <plorth/value-string.hpp>
 
 #include "./utils.hpp"
 

--- a/src/value-quote.cpp
+++ b/src/value-quote.cpp
@@ -652,16 +652,8 @@ namespace plorth
           }
           else if (is_number(text))
           {
-            double num;
-
-            if (to_number(text, num))
-            {
-              slot = ctx->runtime()->value<number>(num);
-              break;
-            }
-            ctx->error(error::code_value, "Unable to parse `" + text + "' into number.");
-
-            return false;
+            slot = ctx->runtime()->number(text);
+            break;
           }
         }
 

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -25,8 +25,6 @@
  */
 #include <plorth/context.hpp>
 #include <plorth/unicode.hpp>
-#include <plorth/value-number.hpp>
-#include <plorth/value-string.hpp>
 
 #include "./utils.hpp"
 

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -204,7 +204,7 @@ namespace plorth
     if (ctx->pop_string(str))
     {
       ctx->push(str);
-      ctx->push_number(str->length());
+      ctx->push_int(str->length());
     }
   }
 
@@ -389,7 +389,7 @@ namespace plorth
 
       for (string::size_type i = 0; i < length; ++i)
       {
-        output[i] = runtime->value<number>(str->at(i));
+        output[i] = runtime->number(static_cast<std::int64_t>(str->at(i)));
       }
       ctx->push(str);
       ctx->push_array(output, length);
@@ -794,17 +794,17 @@ namespace plorth
   static void w_to_number(const ref<context>& ctx)
   {
     ref<string> a;
-    double number;
 
-    if (!ctx->pop_string(a))
+    if (ctx->pop_string(a))
     {
-      return;
-    }
-    else if (to_number(a->to_string(), number))
-    {
-      ctx->push_number(number);
-    } else {
-      ctx->error(error::code_value, "Could not convert string to number.");
+      const unistring str = a->to_string();
+
+      if (is_number(str))
+      {
+        ctx->push_number(str);
+      } else {
+        ctx->error(error::code_value, "Could not convert string to number.");
+      }
     }
   }
 
@@ -857,23 +857,24 @@ namespace plorth
   static void w_repeat(const ref<context>& ctx)
   {
     ref<string> str;
-    double count;
+    ref<number> num;
 
-    if (ctx->pop_string(str) && ctx->pop_number(count))
+    if (ctx->pop_string(str) && ctx->pop_number(num))
     {
       const auto length = str->length();
+      std::int64_t count = num->as_int();
       unistring result;
 
-      if (count < 0.0)
+      if (count < 0)
       {
         count = -count;
       }
 
       result.reserve(length * count);
 
-      while (count >= 1.0)
+      while (count > 0)
       {
-        count -= 1.0;
+        --count;
         for (string::size_type i = 0; i < length; ++i)
         {
           result.append(1, str->at(i));
@@ -902,21 +903,22 @@ namespace plorth
   static void w_get(const ref<context>& ctx)
   {
     ref<string> str;
-    double index;
+    ref<number> num;
 
-    if (ctx->pop_string(str) && ctx->pop_number(index))
+    if (ctx->pop_string(str) && ctx->pop_number(num))
     {
       const auto length = str->length();
+      std::int64_t index = num->as_int();
       unichar c;
 
-      if (index < 0.0)
+      if (index < 0)
       {
         index += length;
       }
 
       ctx->push(str);
 
-      if (index < 0.0 || index > length)
+      if (index < 0 || index > length)
       {
         ctx->error(error::code_range, "String index out of bounds.");
         return;


### PR DESCRIPTION
Supporting only double precision numbers has already caused problems,
especially when comparing numbers against each other. Bring back the
previously removed support for integer numbers, but unlike previously
this time there is only one number class/prototype visible to the
runtime. Details on integer vs. double precision are hidden from the
runtime and visible only to internals of the interpreter, just like in
many JavaScript engines.