### PR TITLE
Modify compiler to use Unicode strings

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -141,7 +141,7 @@ namespace plorth
      * \return       Reference the quote that was compiled from given source,
      *               or null reference if syntax error was encountered.
      */
-    ref<quote> compile(const std::string& source);
+    ref<quote> compile(const unistring& source);
 
     /**
      * Provides direct access to the data stack.

--- a/include/plorth/unicode.hpp
+++ b/include/plorth/unicode.hpp
@@ -47,22 +47,14 @@ namespace plorth
   unistring utf8_decode(const std::string&);
 
   /**
+   * Decodes UTF-8 encoded byte string into Unicode string with validation.
+   */
+  bool utf8_decode_test(const std::string&, unistring&);
+
+  /**
    * Encodes Unicode string into UTF-8 encoded byte string.
    */
   std::string utf8_encode(const unistring&);
-
-  /**
-   * Decodes single Unicode code point from given byte string iterator.
-   *
-   * \param it Current position of the byte string iterator.
-   * \param end Ending point of the byte string iterator.
-   * \param output Where the decoded Unicode code point will be stored into.
-   * \return       Boolean flag which tells whether the decoding was successfull
-   *               or not.
-   */
-  bool utf8_advance(std::string::const_iterator&,
-                    const std::string::const_iterator&,
-                    unichar&);
 
   /**
    * Determines whether given character is valid Unicode code point.

--- a/src/emscripten.cpp
+++ b/src/emscripten.cpp
@@ -32,7 +32,7 @@ static void emscripten_execute(const std::string& source)
     initialize_repl_api(script_runtime);
   }
 
-  if ((quote = script_context->compile(source)))
+  if ((quote = script_context->compile(utf8_decode(source))))
   {
     quote->call(script_context);
   }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -869,7 +869,7 @@ namespace plorth
       return;
     }
 
-    quote = ctx->compile(utf8_encode(source->to_string()));
+    quote = ctx->compile(source->to_string());
     if (quote)
     {
       ctx->push(quote);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -70,17 +70,25 @@ namespace plorth
 
       if (is.good())
       {
-        const std::string source = std::string(
+        const std::string input = std::string(
           std::istreambuf_iterator<char>(is),
           std::istreambuf_iterator<char>()
         );
-        const ref<class quote> compiled_module = ctx->compile(source);
+        unistring source;
+        ref<quote> compiled_module;
         ref<context> module_context;
 
         is.close();
 
+        if (!utf8_decode_test(input, source))
+        {
+          ctx->error(error::code_import, "Unable to decode source code into UTF-8.");
+
+          return false;
+        }
+
         // Did the compilation fail?
-        if (!compiled_module)
+        if (!(compiled_module = ctx->compile(source)))
         {
           return false;
         }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -28,6 +28,9 @@
 namespace plorth
 {
   static inline std::size_t utf8_sequence_length(unsigned char);
+  static bool utf8_advance(std::string::const_iterator&,
+                           const std::string::const_iterator&,
+                           unichar&);
 
   unistring operator+(const char* a, const unistring& b)
   {
@@ -137,9 +140,28 @@ namespace plorth
     return result;
   }
 
-  bool utf8_advance(std::string::const_iterator& it,
-                    const std::string::const_iterator& end,
-                    unichar& result)
+  bool utf8_decode_test(const std::string& input, unistring& output)
+  {
+    auto it = std::begin(input);
+    const auto end = std::end(input);
+
+    while (it != end)
+    {
+      unichar c;
+
+      if (!utf8_advance(it, end, c))
+      {
+        return false;
+      }
+      output.append(1, c);
+    }
+
+    return true;
+  }
+
+  static bool utf8_advance(std::string::const_iterator& it,
+                           const std::string::const_iterator& end,
+                           unichar& result)
   {
     const std::size_t sequence_length = utf8_sequence_length(*it);
 


### PR DESCRIPTION
Instead of having to rely on byte strings that are only assumed to be
UTF-8 encoded, modify the compiler so that it only accepts Unicode
strings. This means that that the decoding must be done by whatever is
calling the compilation, so that the compiler no longer has to worry
about charcter encoding.

This modification is particularily done with WebAssembly target in mind.
Emscripten seems to use UTF-16 as character encoding and is not capable
of handling UTF-8 strings.