### PR TITLE
Add unified print methods to runtime class

### DIFF
--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -120,6 +120,24 @@ namespace plorth
     ref<context> new_context();
 
     /**
+     * Outputs given Unicode string into the standard output stream of the
+     * interpreter.
+     */
+    void print(const unistring& str) const;
+
+    /**
+     * Outputs system specific newline into the standard output stream of the
+     * interpreter.
+     */
+    void println() const;
+
+    /**
+     * Outputs given Unicode string and system specific newline into the
+     * standard output stream of the interpreter.
+     */
+    void println(const unistring& str) const;
+
+    /**
      * Imports module from file system and inserts all of it's exported words
      * into dictionary of given execution context.
      *

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -687,24 +687,6 @@ namespace plorth
   }
 
   /**
-   * Word: print
-   *
-   * Takes:
-   * - any
-   *
-   * Prints top-most value of the stack to stdout.
-   */
-  static void w_print(const ref<context>& ctx)
-  {
-    ref<class value> value;
-
-    if (ctx->pop(value) && value)
-    {
-      std::cout << value;
-    }
-  }
-
-  /**
    * Word: if
    *
    * Takes:
@@ -1062,6 +1044,24 @@ namespace plorth
   }
 
   /**
+   * Word: print
+   *
+   * Takes:
+   * - any
+   *
+   * Prints top-most value of the stack to stdout.
+   */
+  static void w_print(const ref<context>& ctx)
+  {
+    ref<value> val;
+
+    if (ctx->pop(val) && val)
+    {
+      ctx->runtime()->print(val->to_string());
+    }
+  }
+
+  /**
    * Word: println
    *
    * Takes:
@@ -1071,15 +1071,16 @@ namespace plorth
    */
   static void w_println(const ref<context>& ctx)
   {
-    ref<class value> value;
+    const auto& runtime = ctx->runtime();
+    ref<value> val;
 
-    if (ctx->pop(value))
+    if (ctx->pop(val))
     {
-      if (value)
+      if (val)
       {
-        std::cout << value;
+        runtime->print(val->to_string());
       }
-      std::cout << std::endl;
+      runtime->println();
     }
   }
 
@@ -1104,7 +1105,7 @@ namespace plorth
       {
         ctx->error(error::code_range, "Invalid Unicode code point.");
       } else {
-        std::cout << unistring(1, static_cast<unichar>(c));
+        ctx->runtime()->print(unistring(1, static_cast<unichar>(c)));
       }
     }
   }

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -1,5 +1,7 @@
 #include <plorth/context.hpp>
 
+#include "./utils.hpp"
+
 using namespace plorth;
 
 /**
@@ -17,28 +19,25 @@ static void w_quit(const ref<context>&)
  *
  * Displays ten of the top-most values from the data stack.
  */
-static void w_stack(const ref<class context>& context)
+static void w_stack(const ref<context>& ctx)
 {
-  const auto& stack = context->data();
+  const auto& runtime = ctx->runtime();
+  const auto& stack = ctx->data();
   const std::size_t size = stack.size();
 
   if (!size)
   {
-    std::cout << "Stack is empty." << std::endl;
+    runtime->println(utf8_decode("Stack is empty."));
     return;
   }
 
   for (std::size_t i = 0; i < size && i < 10; ++i)
   {
-    const ref<class value>& value = stack[size - i - 1];
-    std::cout << (size - i) << ": ";
-    if (value)
-    {
-      std::cout << value->to_source();
-    } else {
-      std::cout << "null";
-    }
-    std::cout << std::endl;
+    const auto& value = stack[size - i - 1];
+
+    runtime->print(to_unistring(static_cast<std::int64_t>(size - i)) + ": ");
+    runtime->print(value ? value->to_source() : utf8_decode("null"));
+    runtime->println();
   }
 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -72,6 +72,28 @@ namespace plorth
     return new (*m_memory_manager) context(this);
   }
 
+  void runtime::print(const unistring& str) const
+  {
+    std::cout << str;
+  }
+
+  void runtime::println() const
+  {
+#if defined(_WIN32)
+    static const unistring newline = {'\r', '\n'};
+#else
+    static const unistring newline = {'\n'};
+#endif
+
+    print(newline);
+  }
+
+  void runtime::println(const unistring& str) const
+  {
+    print(str);
+    println();
+  }
+
   static inline ref<object> make_prototype(class runtime* runtime,
                                            const char* name,
                                            const runtime::prototype_definition& definition)


### PR DESCRIPTION
Instead of always using `std::cout` as the standard output of the
interpreter, add print methods to the `runtime` class, which can be
overridden for obscure platforms such as WebAssembly.