### PR TITLE
Use C++11 Unicode strings instead of own implementation

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -82,17 +82,6 @@ namespace plorth
     void error(enum error::code code, const unistring& message);
 
     /**
-     * Constructs new error instance with given error code and error message
-     * and replaces this execution state's currently uncaught error with it.
-     *
-     * The error message is expected to be encoded in UTF-8 character encoding.
-     */
-    inline void error(enum error::code code, const char* message)
-    {
-      error(code, utf8_decode(message));
-    }
-
-    /**
      * Removes currently uncaught error in the context.
      */
     inline void clear_error()

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -40,7 +40,7 @@ namespace plorth
   class runtime : public memory::managed
   {
   public:
-    using prototype_definition = std::vector<std::pair<const char*, quote::callback>>;
+    using prototype_definition = std::vector<std::pair<const char32_t*, quote::callback>>;
 
     /**
      * Constructs new runtime.

--- a/include/plorth/token.hpp
+++ b/include/plorth/token.hpp
@@ -163,6 +163,8 @@ namespace plorth
 
   std::ostream& operator<<(std::ostream&, enum token::type);
   std::ostream& operator<<(std::ostream&, const token&);
+  uniostream& operator<<(uniostream&, enum token::type);
+  uniostream& operator<<(uniostream&, const token&);
 }
 
 #endif /* !PLORTH_TOKEN_HPP_GUARD */

--- a/include/plorth/unicode.hpp
+++ b/include/plorth/unicode.hpp
@@ -33,11 +33,13 @@
 
 namespace plorth
 {
-  using unichar = std::uint32_t;
-  using unistring = std::basic_string<unichar>;
+  using unichar = char32_t;
+  using unistring = std::u32string;
+  using uniostream = std::basic_ostream<unichar>;
 
-  unistring operator+(const char*, const unistring&);
-  unistring operator+(const unistring&, const char*);
+  /**
+   * Decodes Unicode string into UTF-8 and outputs it into given byte stream.
+   */
   std::ostream& operator<<(std::ostream&, const unistring&);
 
   /**
@@ -100,33 +102,6 @@ namespace plorth
    * Converts given Unicode character into lower case.
    */
   unichar unichar_tolower(unichar);
-}
-
-namespace std
-{
-  /**
-   * Custom C++11 hashing function for Unicode strings. The hashing algorithm
-   * is stol^H^H^H^Hborrowed from Java.
-   */
-  template<>
-  struct hash<plorth::unistring>
-  {
-    using argument_type = plorth::unistring;
-    using result_type = std::int32_t;
-
-    result_type operator()(const plorth::unistring& s) const
-    {
-      const auto length = s.length();
-      result_type result = 0;
-
-      for (plorth::unistring::size_type i = 0; i < length; ++i)
-      {
-        result = 31 * result + s[i];
-      }
-
-      return result;
-    }
-  };
 }
 
 #endif /* !PLORTH_UNICODE_HPP_GUARD */

--- a/include/plorth/value-error.hpp
+++ b/include/plorth/value-error.hpp
@@ -78,6 +78,7 @@ namespace plorth
   };
 
   std::ostream& operator<<(std::ostream&, enum error::code);
+  uniostream& operator<<(uniostream&, enum error::code);
 }
 
 #endif /* !PLORTH_VALUE_ERROR_HPP_GUARD */

--- a/include/plorth/value.hpp
+++ b/include/plorth/value.hpp
@@ -107,6 +107,9 @@ namespace plorth
 
   std::ostream& operator<<(std::ostream&, enum value::type);
   std::ostream& operator<<(std::ostream&, const ref<value>&);
+
+  uniostream& operator<<(uniostream&, enum value::type);
+  uniostream& operator<<(uniostream&, const ref<value>&);
 }
 
 #endif /* !PLORTH_VALUE_HPP_GUARD */

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -97,7 +97,7 @@ retry_switch:
 
       if (!unichar_isword(c))
       {
-        error(error::code_syntax, "Unexpected input.");
+        error(error::code_syntax, U"Unexpected input.");
 
         return ref<quote>();
       }
@@ -134,7 +134,7 @@ retry_switch:
 
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated string literal.");
+        ctx->error(error::code_syntax, U"Unterminated string literal.");
 
         return false;
       }
@@ -153,7 +153,7 @@ retry_switch:
 
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated string literal.");
+        ctx->error(error::code_syntax, U"Unterminated string literal.");
 
         return false;
       }
@@ -195,13 +195,13 @@ retry_switch:
             {
               if (it >= end)
               {
-                ctx->error(error::code_syntax, "Unterminated string literal.");
+                ctx->error(error::code_syntax, U"Unterminated string literal.");
 
                 return false;
               }
               if (!std::isxdigit(c = *it++))
               {
-                ctx->error(error::code_syntax, "Illegal Unicode hex escape sequence.");
+                ctx->error(error::code_syntax, U"Illegal Unicode hex escape sequence.");
 
                 return false;
               }
@@ -220,7 +220,7 @@ retry_switch:
 
             if (!unichar_validate(result))
             {
-              ctx->error(error::code_syntax, "Illegal Unicode hex escape sequence.");
+              ctx->error(error::code_syntax, U"Illegal Unicode hex escape sequence.");
 
               return false;
             }
@@ -230,7 +230,7 @@ retry_switch:
           break;
 
         default:
-          ctx->error(error::code_syntax, "Illegal escape sequence in string literal.");
+          ctx->error(error::code_syntax, U"Illegal escape sequence in string literal.");
 
           return false;
       }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -108,7 +108,7 @@ namespace plorth
     }
 
     // Otherwise it's reference error.
-    error(error::code_reference, "Unrecognized word: `" + word + "'");
+    error(error::code_reference, U"Unrecognized word: `" + word + U"'");
 
     return false;
   }
@@ -171,7 +171,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, "Stack underflow.");
+    error(error::code_range, U"Stack underflow.");
 
     return false;
   }
@@ -184,17 +184,17 @@ namespace plorth
 
       if ((!value && type != value::type_null) || (value && !value->is(type)))
       {
-        std::stringstream ss;
+        std::basic_stringstream<char32_t> ss;
 
-        ss << "Expected " << type << ", got ";
+        ss << U"Expected " << type << U", got ";
         if (value)
         {
           ss << value->type();
         } else {
-          ss << "null";
+          ss << U"null";
         }
-        ss << " instead.";
-        error(error::code_type, ss.str().c_str());
+        ss << U" instead.";
+        error(error::code_type, ss.str());
 
         return false;
       }
@@ -202,7 +202,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, "Stack underflow.");
+    error(error::code_range, U"Stack underflow.");
 
     return false;
   }
@@ -216,7 +216,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, "Stack underflow.");
+    error(error::code_range, U"Stack underflow.");
 
     return false;
   }
@@ -228,17 +228,17 @@ namespace plorth
       slot = m_data.back();
       if ((!slot && type != value::type_null) || (slot && !slot->is(type)))
       {
-        std::stringstream ss;
+        std::basic_stringstream<char32_t> ss;
 
-        ss << "Expected " << type << ", got ";
+        ss << U"Expected " << type << U", got ";
         if (slot)
         {
           ss << slot->type();
         } else {
-          ss << "null";
+          ss << U"null";
         }
-        ss << " instead.";
-        error(error::code_type, ss.str().c_str());
+        ss << U" instead.";
+        error(error::code_type, ss.str());
 
         return false;
       }
@@ -246,7 +246,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, "Stack underflow.");
+    error(error::code_range, U"Stack underflow.");
 
     return false;
   }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -564,12 +564,12 @@ namespace plorth
       ctx->push(value);
       if (value)
       {
-        std::stringstream ss;
+        std::basic_stringstream<char32_t> ss;
 
         ss << value->type();
-        ctx->push_string(utf8_decode(ss.str()));
+        ctx->push_string(ss.str());
       } else {
-        ctx->push_string(utf8_decode("null"));
+        ctx->push_string(U"null");
       }
     }
   }
@@ -655,7 +655,7 @@ namespace plorth
     {
       ctx->push_string(value->to_string());
     } else {
-      ctx->push_string(utf8_decode(""));
+      ctx->push_string(U"");
     }
   }
 
@@ -683,7 +683,7 @@ namespace plorth
     {
       ctx->push_string(value->to_source());
     } else {
-      ctx->push_string(utf8_decode("null"));
+      ctx->push_string(U"null");
     }
   }
 
@@ -965,10 +965,10 @@ namespace plorth
       {
         message = val.cast<string>()->to_string();
       } else {
-        std::stringstream ss;
+        std::basic_stringstream<char32_t> ss;
 
-        ss << "Expected string, got " << val->type() << " instead.";
-        ctx->error(error::code_type, utf8_decode(ss.str()));
+        ss << U"Expected string, got " << val->type() << U" instead.";
+        ctx->error(error::code_type, ss.str());
         return;
       }
     }
@@ -1106,7 +1106,7 @@ namespace plorth
 
       if (!unichar_validate(c))
       {
-        ctx->error(error::code_range, "Invalid Unicode code point.");
+        ctx->error(error::code_range, U"Invalid Unicode code point.");
       } else {
         ctx->runtime()->print(unistring(1, static_cast<unichar>(c)));
       }
@@ -1180,75 +1180,75 @@ namespace plorth
       return
       {
         // Constants.
-        { "null", w_null },
-        { "true", w_true },
-        { "false", w_false },
-        { "e", w_e },
-        { "pi", w_pi },
+        { U"null", w_null },
+        { U"true", w_true },
+        { U"false", w_false },
+        { U"e", w_e },
+        { U"pi", w_pi },
 
         // Stack manipulation.
-        { "nop", w_nop },
-        { "clear", w_clear },
-        { "depth", w_depth },
-        { "drop", w_drop },
-        { "2drop", w_drop2 },
-        { "dup", w_dup },
-        { "2dup", w_dup2 },
-        { "nip", w_nip },
-        { "over", w_over },
-        { "rot", w_rot },
-        { "swap", w_swap },
-        { "tuck", w_tuck },
+        { U"nop", w_nop },
+        { U"clear", w_clear },
+        { U"depth", w_depth },
+        { U"drop", w_drop },
+        { U"2drop", w_drop2 },
+        { U"dup", w_dup },
+        { U"2dup", w_dup2 },
+        { U"nip", w_nip },
+        { U"over", w_over },
+        { U"rot", w_rot },
+        { U"swap", w_swap },
+        { U"tuck", w_tuck },
 
         // Value types.
-        { "array?", w_is_array },
-        { "boolean?", w_is_boolean },
-        { "error?", w_is_error },
-        { "null?", w_is_null },
-        { "number?", w_is_number },
-        { "object?", w_is_object },
-        { "quote?", w_is_quote },
-        { "string?", w_is_string },
-        { "typeof" , w_typeof },
-        { "proto", w_proto },
+        { U"array?", w_is_array },
+        { U"boolean?", w_is_boolean },
+        { U"error?", w_is_error },
+        { U"null?", w_is_null },
+        { U"number?", w_is_number },
+        { U"object?", w_is_object },
+        { U"quote?", w_is_quote },
+        { U"string?", w_is_string },
+        { U"typeof" , w_typeof },
+        { U"proto", w_proto },
 
         // Conversions.
-        { ">boolean", w_to_boolean },
-        { ">string", w_to_string },
-        { ">source", w_to_source },
+        { U">boolean", w_to_boolean },
+        { U">string", w_to_string },
+        { U">source", w_to_source },
 
         // Logic.
-        { "if", w_if },
-        { "if-else", w_if_else },
-        { "while", w_while },
-        { "try", w_try },
-        { "try-else", w_try_else },
+        { U"if", w_if },
+        { U"if-else", w_if_else },
+        { U"while", w_while },
+        { U"try", w_try },
+        { U"try-else", w_try_else },
 
         // Interpreter related.
-        { "compile", w_compile },
-        { "globals", w_globals },
-        { "locals", w_locals },
-        { "const", w_const },
-        { "import", w_import },
-        { "args", w_args },
+        { U"compile", w_compile },
+        { U"globals", w_globals },
+        { U"locals", w_locals },
+        { U"const", w_const },
+        { U"import", w_import },
+        { U"args", w_args },
 
         // Different types of errors.
-        { "type-error", w_type_error },
-        { "value-error", w_value_error },
-        { "range-error", w_range_error },
-        { "unknown-error", w_unknown_error },
+        { U"type-error", w_type_error },
+        { U"value-error", w_value_error },
+        { U"range-error", w_range_error },
+        { U"unknown-error", w_unknown_error },
 
         // I/O related.
-        { "print", w_print },
-        { "println", w_println },
-        { "emit", w_emit },
+        { U"print", w_print },
+        { U"println", w_println },
+        { U"emit", w_emit },
 
         // Random utilities.
-        { "now", w_now },
+        { U"now", w_now },
 
         // Global operators.
-        { "=", w_eq },
-        { "!=", w_ne },
+        { U"=", w_eq },
+        { U"!=", w_ne },
       };
     }
   }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -36,7 +36,7 @@ namespace plorth
     // Do not import empty paths.
     if (path.empty() || std::all_of(path.begin(), path.end(), unichar_isspace))
     {
-      ctx->error(error::code_import, "Empty import path.");
+      ctx->error(error::code_import, U"Empty import path.");
 
       return false;
     }
@@ -49,7 +49,7 @@ namespace plorth
     // First attempt to resolve the module path into actual file system path.
     if (!resolve_path(path, resolved_path, m_module_paths))
     {
-      ctx->error(error::code_import, "No such file or directory.");
+      ctx->error(error::code_import, U"No such file or directory.");
 
       return false;
     }
@@ -82,7 +82,7 @@ namespace plorth
 
         if (!utf8_decode_test(input, source))
         {
-          ctx->error(error::code_import, "Unable to decode source code into UTF-8.");
+          ctx->error(error::code_import, U"Unable to decode source code into UTF-8.");
 
           return false;
         }
@@ -101,7 +101,7 @@ namespace plorth
           {
             ctx->error(module_context->error());
           } else {
-            ctx->error(error::code_import, "Module import failed.");
+            ctx->error(error::code_import, U"Module import failed.");
           }
 
           return false;
@@ -111,7 +111,7 @@ namespace plorth
         module = value<object>(module_context->dictionary());
         m_imported_modules[resolved_path] = module;
       } else {
-        ctx->error(error::code_import, "Unable to import `" + resolved_path + "'");
+        ctx->error(error::code_import, U"Unable to import `" + resolved_path + U"'");
 
         return false;
       }
@@ -126,7 +126,7 @@ namespace plorth
 
     return true;
 #else
-    ctx->error(error::code_import, "Modules have been disabled.");
+    ctx->error(error::code_import, U"Modules have been disabled.");
 
     return false;
 #endif

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -27,7 +27,7 @@ static void w_stack(const ref<context>& ctx)
 
   if (!size)
   {
-    runtime->println(utf8_decode("Stack is empty."));
+    runtime->println(U"Stack is empty.");
     return;
   }
 
@@ -35,8 +35,8 @@ static void w_stack(const ref<context>& ctx)
   {
     const auto& value = stack[size - i - 1];
 
-    runtime->print(to_unistring(static_cast<std::int64_t>(size - i)) + ": ");
-    runtime->print(value ? value->to_source() : utf8_decode("null"));
+    runtime->print(to_unistring(static_cast<std::int64_t>(size - i)) + U": ");
+    runtime->print(value ? value->to_source() : U"null");
     runtime->println();
   }
 }
@@ -45,6 +45,6 @@ void initialize_repl_api(const ref<runtime>& runtime)
 {
   auto& dictionary = runtime->dictionary();
 
-  dictionary[utf8_decode(".q")] = runtime->native_quote(w_quit);
-  dictionary[utf8_decode(".s")] = runtime->native_quote(w_stack);
+  dictionary[U".q"] = runtime->native_quote(w_quit);
+  dictionary[U".s"] = runtime->native_quote(w_stack);
 }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -43,7 +43,7 @@ namespace plorth
     runtime::prototype_definition string_prototype();
   }
 
-  static inline ref<object> make_prototype(runtime*, const char*, const runtime::prototype_definition&);
+  static inline ref<object> make_prototype(runtime*, const char32_t*, const runtime::prototype_definition&);
 
   runtime::runtime(memory::manager* memory_manager)
     : m_memory_manager(memory_manager)
@@ -55,16 +55,16 @@ namespace plorth
 
     for (auto& entry : api::global_dictionary())
     {
-      m_dictionary[utf8_decode(entry.first)] = native_quote(entry.second);
+      m_dictionary[entry.first] = native_quote(entry.second);
     }
 
-    m_object_prototype = make_prototype(this, "object", api::object_prototype());
-    m_array_prototype = make_prototype(this, "array", api::array_prototype());
-    m_boolean_prototype = make_prototype(this, "boolean", api::boolean_prototype());
-    m_error_prototype = make_prototype(this, "error", api::error_prototype());
-    m_number_prototype = make_prototype(this, "number", api::number_prototype());
-    m_quote_prototype = make_prototype(this, "quote", api::quote_prototype());
-    m_string_prototype = make_prototype(this, "string", api::string_prototype());
+    m_object_prototype = make_prototype(this, U"object", api::object_prototype());
+    m_array_prototype = make_prototype(this, U"array", api::array_prototype());
+    m_boolean_prototype = make_prototype(this, U"boolean", api::boolean_prototype());
+    m_error_prototype = make_prototype(this, U"error", api::error_prototype());
+    m_number_prototype = make_prototype(this, U"number", api::number_prototype());
+    m_quote_prototype = make_prototype(this, U"quote", api::quote_prototype());
+    m_string_prototype = make_prototype(this, U"string", api::string_prototype());
   }
 
   ref<context> runtime::new_context()
@@ -95,7 +95,7 @@ namespace plorth
   }
 
   static inline ref<object> make_prototype(class runtime* runtime,
-                                           const char* name,
+                                           const char32_t* name,
                                            const runtime::prototype_definition& definition)
   {
     object::container_type properties;
@@ -103,13 +103,13 @@ namespace plorth
 
     for (auto& entry : definition)
     {
-      properties[utf8_decode(entry.first)] = runtime->native_quote(entry.second);
+      properties[entry.first] = runtime->native_quote(entry.second);
     }
-    properties[utf8_decode("prototype")] = runtime->object_prototype();
+    properties[U"prototype"] = runtime->object_prototype();
 
     prototype = runtime->value<object>(properties);
-    runtime->dictionary()[utf8_decode(name)] = runtime->value<object>(object::container_type({
-      { utf8_decode("prototype"), prototype }
+    runtime->dictionary()[name] = runtime->value<object>(object::container_type({
+      { U"prototype", prototype }
     }));
 
     return prototype;

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -72,44 +72,44 @@ namespace plorth
 
   unistring token::to_source() const
   {
-    const char* str;
+    const char32_t* str;
 
     switch (m_type)
     {
       case type_lparen:
-        str = "(";
+        str = U"(";
         break;
 
       case type_rparen:
-        str = ")";
+        str = U")";
         break;
 
       case type_lbrack:
-        str = "[";
+        str = U"[";
         break;
 
       case type_rbrack:
-        str = "]";
+        str = U"]";
         break;
 
       case type_lbrace:
-        str = "{";
+        str = U"{";
         break;
 
       case type_rbrace:
-        str = "}";
+        str = U"}";
         break;
 
       case type_colon:
-        str = ":";
+        str = U":";
         break;
 
       case type_semicolon:
-        str = ";";
+        str = U";";
         break;
 
       case type_comma:
-        str = ",";
+        str = U",";
         break;
 
       case type_word:
@@ -119,7 +119,7 @@ namespace plorth
         return json_stringify(m_text);
     }
 
-    return utf8_decode(str);
+    return str;
   }
 
   std::ostream& operator<<(std::ostream& out, enum token::type type)
@@ -186,7 +186,82 @@ namespace plorth
 
       if (text.length() > 15)
       {
-        out << json_stringify(text.substr(0, 15) + "...");
+        out << json_stringify(text.substr(0, 15) + U"...");
+      } else {
+        out << json_stringify(text);
+      }
+    } else {
+      out << token.type();
+    }
+
+    return out;
+  }
+
+  uniostream& operator<<(uniostream& out, enum token::type type)
+  {
+    switch (type)
+    {
+    case token::type_lparen:
+      out << U"`('";
+      break;
+
+    case token::type_rparen:
+      out << U"`)'";
+      break;
+
+    case token::type_lbrack:
+      out << U"`['";
+      break;
+
+    case token::type_rbrack:
+      out << U"`]'";
+      break;
+
+    case token::type_lbrace:
+      out << U"`{'";
+      break;
+
+    case token::type_rbrace:
+      out << U"`}'";
+      break;
+
+    case token::type_colon:
+      out << U"`:'";
+      break;
+
+    case token::type_semicolon:
+      out << U"`;'";
+      break;
+
+    case token::type_comma:
+      out << U"`,'";
+      break;
+
+    case token::type_word:
+      out << U"word";
+      break;
+
+    case token::type_string:
+      out << U"string literal";
+      break;
+    }
+
+    return out;
+  }
+
+  uniostream& operator<<(uniostream& out, const class token& token)
+  {
+    if (token.is(token::type_word))
+    {
+      out << U"`" << token.text() << U"'";
+    }
+    else if (token.is(token::type_string))
+    {
+      const unistring& text = token.text();
+
+      if (text.length() > 15)
+      {
+        out << json_stringify(text.substr(0, 15) + U"...");
       } else {
         out << json_stringify(text);
       }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -32,16 +32,6 @@ namespace plorth
                            const std::string::const_iterator&,
                            unichar&);
 
-  unistring operator+(const char* a, const unistring& b)
-  {
-    return utf8_decode(a) + b;
-  }
-
-  unistring operator+(const unistring& a, const char* b)
-  {
-    return a + utf8_decode(b);
-  }
-
   std::ostream& operator<<(std::ostream& out, const unistring& s)
   {
     for (const auto& c : s)

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -171,7 +171,7 @@ namespace plorth
       {
         result += element->to_source();
       } else {
-        result += utf8_decode("null");
+        result += U"null";
       }
     }
     result += ']';
@@ -594,7 +594,7 @@ namespace plorth
       {
         result += element->to_string();
       } else {
-        result += utf8_decode("null");
+        result += U"null";
       }
     }
 
@@ -745,7 +745,7 @@ namespace plorth
 
     if (size == 0)
     {
-      ctx->error(error::code_range, "Cannot reduce empty array.");
+      ctx->error(error::code_range, U"Cannot reduce empty array.");
       return;
     }
 
@@ -824,7 +824,7 @@ namespace plorth
         }
         ctx->push_array(result.data(), size * count);
       } else {
-        ctx->error(error::code_range, "Invalid repeat count.");
+        ctx->error(error::code_range, U"Invalid repeat count.");
       }
     }
   }
@@ -993,7 +993,7 @@ namespace plorth
 
       if (index < 0 || index > static_cast<std::int64_t>(ary->size()))
       {
-        ctx->error(error::code_range, "Array index out of bounds.");
+        ctx->error(error::code_range, U"Array index out of bounds.");
         return;
       }
 
@@ -1056,33 +1056,33 @@ namespace plorth
     {
       return
       {
-        { "length", w_length },
+        { U"length", w_length },
 
         // Search methods.
-        { "includes?", w_includes },
-        { "index-of", w_index_of },
-        { "find", w_find },
-        { "find-index", w_find_index },
-        { "every?", w_every },
-        { "some?", w_some },
+        { U"includes?", w_includes },
+        { U"index-of", w_index_of },
+        { U"find", w_find },
+        { U"find-index", w_find_index },
+        { U"every?", w_every },
+        { U"some?", w_some },
 
         // Conversions.
-        { "reverse", w_reverse },
-        { "uniq", w_uniq },
-        { "extract", w_extract },
-        { "join", w_join },
+        { U"reverse", w_reverse },
+        { U"uniq", w_uniq },
+        { U"extract", w_extract },
+        { U"join", w_join },
 
-        { "for-each", w_for_each },
-        { "map", w_map },
-        { "filter", w_filter },
-        { "reduce", w_reduce },
+        { U"for-each", w_for_each },
+        { U"map", w_map },
+        { U"filter", w_filter },
+        { U"reduce", w_reduce },
 
-        { "+", w_concat },
-        { "*", w_repeat },
-        { "&", w_intersect },
-        { "|", w_union },
-        { "@", w_get },
-        { "!", w_set }
+        { U"+", w_concat },
+        { U"*", w_repeat },
+        { U"&", w_intersect },
+        { U"|", w_union },
+        { U"@", w_get },
+        { U"!", w_set }
       };
     }
   }

--- a/src/value-boolean.cpp
+++ b/src/value-boolean.cpp
@@ -42,7 +42,7 @@ namespace plorth
 
   unistring boolean::to_string() const
   {
-    return utf8_decode(m_value ? "true" : "false");
+    return m_value ? U"true" : U"false";
   }
 
   unistring boolean::to_source() const
@@ -150,10 +150,10 @@ namespace plorth
     {
       return
       {
-        { "and", w_and },
-        { "or", w_or },
-        { "xor", w_xor },
-        { "not", w_not },
+        { U"and", w_and },
+        { U"or", w_or },
+        { U"xor", w_xor },
+        { U"not", w_not },
       };
     }
   }

--- a/src/value-error.cpp
+++ b/src/value-error.cpp
@@ -49,20 +49,20 @@ namespace plorth
 
   unistring error::to_string() const
   {
-    std::stringstream ss;
+    std::basic_stringstream<char32_t> ss;
 
     ss << m_code;
     if (!m_message.empty())
     {
-      ss << ": " << m_message;
+      ss << U": " << m_message;
     }
 
-    return utf8_decode(ss.str());
+    return ss.str();
   }
 
   unistring error::to_source() const
   {
-    return "<" + to_string() + ">";
+    return U"<" + to_string() + U">";
   }
 
   std::ostream& operator<<(std::ostream& out, enum error::code code)
@@ -96,6 +96,42 @@ namespace plorth
       case error::code_unknown:
         out << "Unknown error";
         break;
+    }
+
+    return out;
+  }
+
+  uniostream& operator<<(uniostream& out, enum error::code code)
+  {
+    switch (code)
+    {
+    case error::code_syntax:
+      out << U"Syntax error";
+      break;
+
+    case error::code_reference:
+      out << U"Reference error";
+      break;
+
+    case error::code_type:
+      out << U"Type error";
+      break;
+
+    case error::code_value:
+      out << U"Value error";
+      break;
+
+    case error::code_range:
+      out << U"Range error";
+      break;
+
+    case error::code_import:
+      out << U"Import error";
+      break;
+
+    case error::code_unknown:
+      out << U"Unknown error";
+      break;
     }
 
     return out;
@@ -182,9 +218,9 @@ namespace plorth
     {
       return
       {
-        { "code", w_code },
-        { "message", w_message },
-        { "throw", w_throw },
+        { U"code", w_code },
+        { U"message", w_message },
+        { U"throw", w_throw },
       };
     }
   }

--- a/src/value-number.cpp
+++ b/src/value-number.cpp
@@ -808,30 +808,30 @@ namespace plorth
     {
       return
       {
-        { "nan?", w_is_nan },
-        { "finite?", w_is_finite },
+        { U"nan?", w_is_nan },
+        { U"finite?", w_is_finite },
 
-        { "times", w_times },
+        { U"times", w_times },
 
-        { "abs", w_abs },
-        { "round", w_round },
-        { "floor", w_floor },
-        { "ceil", w_ceil },
-        { "max", w_max },
-        { "min", w_min },
-        { "clamp", w_clamp },
-        { "in-range?", w_is_in_range },
+        { U"abs", w_abs },
+        { U"round", w_round },
+        { U"floor", w_floor },
+        { U"ceil", w_ceil },
+        { U"max", w_max },
+        { U"min", w_min },
+        { U"clamp", w_clamp },
+        { U"in-range?", w_is_in_range },
 
-        { "+", w_add },
-        { "-", w_sub },
-        { "*", w_mul },
-        { "/", w_div },
-        { "%", w_mod },
+        { U"+", w_add },
+        { U"-", w_sub },
+        { U"*", w_mul },
+        { U"/", w_div },
+        { U"%", w_mod },
 
-        { "<", w_lt },
-        { ">", w_gt },
-        { "<=", w_lte },
-        { ">=", w_gte }
+        { U"<", w_lt },
+        { U">", w_gt },
+        { U"<=", w_lte },
+        { U">=", w_gte }
       };
     }
   }

--- a/src/value-object.cpp
+++ b/src/value-object.cpp
@@ -135,7 +135,7 @@ namespace plorth
       {
         result += property.second->to_source();
       } else {
-        result += utf8_decode("null");
+        result += U"null";
       }
     }
     result += '}';
@@ -295,16 +295,16 @@ namespace plorth
       return;
     }
 
-    if (!obj->property(runtime, utf8_decode("prototype"), prototype, false)
+    if (!obj->property(runtime, U"prototype", prototype, false)
         || !prototype->is(value::type_object))
     {
-      ctx->error(error::code_type, "Object has no prototype.");
+      ctx->error(error::code_type, U"Object has no prototype.");
       return;
     }
 
-    ctx->push_object({ { utf8_decode("__proto__"), prototype } });
+    ctx->push_object({ { U"__proto__", prototype } });
 
-    if (prototype.cast<object>()->property(runtime, utf8_decode("constructor"), constructor)
+    if (prototype.cast<object>()->property(runtime, U"constructor", constructor)
         && constructor->is(value::type_quote))
     {
       constructor.cast<quote>()->call(ctx);
@@ -343,7 +343,7 @@ namespace plorth
       } else {
         ctx->error(
           error::code_range,
-          "No such property: `" + id->to_string() + "'"
+          U"No such property: `" + id->to_string() + U"'"
         );
       }
     }
@@ -416,14 +416,14 @@ namespace plorth
     {
       return
       {
-        { "keys", w_keys },
-        { "values", w_values },
-        { "has?", w_has },
-        { "has-own?", w_has_own },
-        { "new", w_new },
-        { "@", w_get },
-        { "!", w_set },
-        { "+", w_concat }
+        { U"keys", w_keys },
+        { U"values", w_values },
+        { U"has?", w_has },
+        { U"has-own?", w_has_own },
+        { U"new", w_new },
+        { U"@", w_get },
+        { U"!", w_set },
+        { U"+", w_concat }
       };
     }
   }

--- a/src/value-quote.cpp
+++ b/src/value-quote.cpp
@@ -28,8 +28,6 @@
 
 #include "./utils.hpp"
 
-#include <sstream>
-
 namespace plorth
 {
   static bool parse_value(const ref<context>& ctx,
@@ -104,14 +102,12 @@ namespace plorth
             case token::type_rbrace:
             case token::type_comma:
             case token::type_semicolon:
-              {
-                std::stringstream ss;
+              ctx->error(
+                error::code_syntax,
+                U"Unexpected `" + current->to_source() + U"'"
+              );
 
-                ss << "Unexpected " << *current;
-                ctx->error(error::code_syntax, ss.str().c_str());
-
-                return false;
-              }
+              return false;
           }
         }
 
@@ -191,7 +187,7 @@ namespace plorth
 
       unistring to_source() const
       {
-        return utf8_decode("(\"native quote\")");
+        return U"(\"native quote\")";
       }
 
       bool equals(const ref<value>& that) const
@@ -248,7 +244,7 @@ namespace plorth
         result += m_argument->to_source();
         result += ' ';
         result += m_quote->to_source();
-        result += utf8_decode(" curry");
+        result += U" curry";
 
         return result;
       }
@@ -299,7 +295,7 @@ namespace plorth
         result += m_left->to_source();
         result += ' ';
         result += m_right->to_source();
-        result += utf8_decode(" compose");
+        result += U" compose";
 
         return result;
       }
@@ -351,7 +347,7 @@ namespace plorth
 
       unistring to_source() const
       {
-        return m_quote->to_source() + " negate";
+        return m_quote->to_source() + U" negate";
       }
 
     private:
@@ -402,7 +398,7 @@ namespace plorth
         {
           result += m_value->to_source();
         } else {
-          result += utf8_decode("null");
+          result += U"null";
         }
         result += ')';
 
@@ -467,7 +463,7 @@ namespace plorth
     }
     if (counter > 0)
     {
-      ctx->error(error::code_syntax, "Unterminated quote.");
+      ctx->error(error::code_syntax, U"Unterminated quote.");
 
       return ref<quote>();
     }
@@ -486,7 +482,7 @@ namespace plorth
     {
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated array literal.");
+        ctx->error(error::code_syntax, U"Unterminated array literal.");
 
         return ref<array>();
       }
@@ -502,7 +498,7 @@ namespace plorth
       elements.push_back(val);
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated array literal.");
+        ctx->error(error::code_syntax, U"Unterminated array literal.");
 
         return ref<array>();
       }
@@ -512,10 +508,10 @@ namespace plorth
       }
       else if (!it->is(token::type_rbrack))
       {
-        std::stringstream ss;
-
-        ss << "Unexpected " << *it << "; Missing `]'";
-        ctx->error(error::code_syntax, ss.str().c_str());
+        ctx->error(
+          error::code_syntax,
+          U"Unexpected `" + it->to_source() + U"'; Missing `]'"
+        );
 
         return ref<array>();
       }
@@ -536,7 +532,7 @@ namespace plorth
     {
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated object literal.");
+        ctx->error(error::code_syntax, U"Unterminated object literal.");
 
         return ref<object>();
       }
@@ -547,14 +543,14 @@ namespace plorth
       }
       else if (!it->is(token::type_string))
       {
-        ctx->error(error::code_syntax, "Missing key for object literal.");
+        ctx->error(error::code_syntax, U"Missing key for object literal.");
 
         return ref<object>();
       }
       id = it++->text();
       if (it >= end || !it++->is(token::type_colon))
       {
-        ctx->error(error::code_syntax, "Missing `:' after key of an object.");
+        ctx->error(error::code_syntax, U"Missing `:' after key of an object.");
 
         return ref<object>();
       }
@@ -565,7 +561,7 @@ namespace plorth
       properties[id] = val;
       if (it >= end)
       {
-        ctx->error(error::code_syntax, "Unterminated object literal.");
+        ctx->error(error::code_syntax, U"Unterminated object literal.");
 
         return ref<object>();
       }
@@ -575,10 +571,10 @@ namespace plorth
       }
       else if (!it->is(token::type_rbrace))
       {
-        std::stringstream ss;
-
-        ss << "Unexpected " << *it << "; Missing `]'";
-        ctx->error(error::code_syntax, ss.str().c_str());
+        ctx->error(
+          error::code_syntax,
+          U"Unexpected `" + it->to_source() + U"'; Missing `]'"
+        );
 
         return ref<object>();
       }
@@ -625,22 +621,22 @@ namespace plorth
         {
           const unistring& text = token.text();
 
-          if (!text.compare(utf8_decode("null")))
+          if (!text.compare(U"null"))
           {
             slot.release();
             break;
           }
-          else if (!text.compare(utf8_decode("true")))
+          else if (!text.compare(U"true"))
           {
             slot = ctx->runtime()->true_value();
             break;
           }
-          else if (!text.compare(utf8_decode("false")))
+          else if (!text.compare(U"false"))
           {
             slot = ctx->runtime()->false_value();
             break;
           }
-          else if (!text.compare(utf8_decode("drop")))
+          else if (!text.compare(U"drop"))
           {
             if (!ctx->pop(slot))
             {
@@ -656,14 +652,12 @@ namespace plorth
         }
 
       default:
-        {
-          std::stringstream ss;
+        ctx->error(
+          error::code_syntax,
+          U"Unexpected `" + token.to_source() + U"', missing value."
+        );
 
-          ss << "Unexpected " << token << ", expected value.";
-          ctx->error(error::code_syntax, ss.str().c_str());
-
-          return false;
-        }
+        return false;
     }
 
     return true;
@@ -679,7 +673,7 @@ namespace plorth
 
     if (++current >= end || !current->is(token::type_word))
     {
-      ctx->error(error::code_syntax, "Missing name after word declaration.");
+      ctx->error(error::code_syntax, U"Missing name after word declaration.");
 
       return false;
     }
@@ -700,7 +694,7 @@ namespace plorth
     }
     if (counter > 0)
     {
-      ctx->error(error::code_syntax, "Unterminated declaration.");
+      ctx->error(error::code_syntax, U"Unterminated declaration.");
 
       return false;
     }
@@ -806,10 +800,10 @@ namespace plorth
     {
       return
       {
-        { "call", w_call },
-        { "compose", w_compose },
-        { "curry", w_curry },
-        { "negate", w_negate }
+        { U"call", w_call },
+        { U"compose", w_compose },
+        { U"curry", w_curry },
+        { U"negate", w_negate }
       };
     }
   }

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -803,7 +803,7 @@ namespace plorth
       {
         ctx->push_number(str);
       } else {
-        ctx->error(error::code_value, "Could not convert string to number.");
+        ctx->error(error::code_value, U"Could not convert string to number.");
       }
     }
   }
@@ -920,7 +920,7 @@ namespace plorth
 
       if (index < 0 || index > static_cast<std::int64_t>(length))
       {
-        ctx->error(error::code_range, "String index out of bounds.");
+        ctx->error(error::code_range, U"String index out of bounds.");
         return;
       }
 
@@ -935,41 +935,41 @@ namespace plorth
     {
       return
       {
-        { "length", w_length },
-        { "chars", w_chars },
-        { "runes", w_runes },
-        { "words", w_words },
-        { "lines", w_lines },
+        { U"length", w_length },
+        { U"chars", w_chars },
+        { U"runes", w_runes },
+        { U"words", w_words },
+        { U"lines", w_lines },
 
         // Tests.
         // TODO: includes?
         // TODO: index-of
         // TODO: starts-with?
         // TODO: ends-with?
-        { "space?", w_is_space },
-        { "lower-case?", w_is_lower_case },
-        { "upper-case?", w_is_upper_case },
+        { U"space?", w_is_space },
+        { U"lower-case?", w_is_lower_case },
+        { U"upper-case?", w_is_upper_case },
 
         // Conversions.
-        { "reverse", w_reverse },
-        { "upper-case", w_upper_case },
-        { "lower-case", w_lower_case },
-        { "swap-case", w_swap_case },
-        { "capitalize", w_capitalize },
-        { "trim", w_trim },
-        { "trim-left", w_trim_left },
-        { "trim-right", w_trim_right },
+        { U"reverse", w_reverse },
+        { U"upper-case", w_upper_case },
+        { U"lower-case", w_lower_case },
+        { U"swap-case", w_swap_case },
+        { U"capitalize", w_capitalize },
+        { U"trim", w_trim },
+        { U"trim-left", w_trim_left },
+        { U"trim-right", w_trim_right },
         // TODO: pad-left
         // TODO: pad-right
         // TODO: substring
         // TODO: split
         // TODO: replace
         // TODO: normalize
-        { ">number", w_to_number },
+        { U">number", w_to_number },
 
-        { "+", w_concat },
-        { "*", w_repeat },
-        { "@", w_get }
+        { U"+", w_concat },
+        { U"*", w_repeat },
+        { U"@", w_get }
       };
     }
   }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -57,7 +57,7 @@ namespace plorth
       case type_object:
         {
           const auto& properties = static_cast<const object*>(this)->properties();
-          const auto property = properties.find(utf8_decode("__proto__"));
+          const auto property = properties.find(U"__proto__");
 
           if (property == std::end(properties))
           {
@@ -134,6 +134,59 @@ namespace plorth
       os << value->to_string();
     } else {
       os << "<no value>";
+    }
+
+    return os;
+  }
+
+  uniostream& operator<<(uniostream& os, enum value::type type)
+  {
+    switch (type)
+    {
+    case value::type_null:
+      os << U"null";
+      break;
+
+    case value::type_boolean:
+      os << U"boolean";
+      break;
+
+    case value::type_number:
+      os << U"number";
+      break;
+
+    case value::type_string:
+      os << U"string";
+      break;
+
+    case value::type_array:
+      os << U"array";
+      break;
+
+    case value::type_object:
+      os << U"object";
+      break;
+
+    case value::type_quote:
+      os << U"quote";
+      break;
+
+    case value::type_error:
+      os << U"error";
+      break;
+
+    }
+
+    return os;
+  }
+
+  uniostream& operator<<(uniostream& os, const ref<class value>& value)
+  {
+    if (value)
+    {
+      os << value->to_string();
+    } else {
+      os << U"<no value>";
     }
 
     return os;


### PR DESCRIPTION
C++11 has perfectly usable implementations of characters and strings
that use Unicode code points instead of bytes or "wide characters" that
can be especially painful to use.

Instead of having our own string implementation `unistring` which is
typedef of `std::basic_string<std::uint32_t>`, use the one provided by
standard C++ library. Keep the typedef at least for now for backward
compatibility.

The new `std::u32string` requires some tweaking with stream operators,
but overall it's worth it, especially because we can now use new
`U"..."` string literals.