### PR TITLE
Use real division operators instead of flooring ones

### DIFF
--- a/src/value-number.cpp
+++ b/src/value-number.cpp
@@ -631,20 +631,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
-      {
-        ctx->push_real(a->as_real() / b->as_real());
-      } else {
-        const std::int64_t x = a->as_int();
-        const std::int64_t y = a->as_int();
-
-        if (y == 0)
-        {
-          ctx->push_real(y < 0 ? -INFINITY : INFINITY);
-        } else {
-          ctx->push_int(x / y);
-        }
-      }
+      ctx->push_real(a->as_real() / b->as_real());
     }
   }
 
@@ -669,20 +656,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
-      {
-        ctx->push_real(std::fmod(a->as_real(), b->as_real()));
-      } else {
-        const std::int64_t x = a->as_int();
-        const std::int64_t y = a->as_int();
-
-        if (y == 0)
-        {
-          ctx->push_real(NAN);
-        } else {
-          ctx->push_int(x % y);
-        }
-      }
+      ctx->push_real(std::fmod(a->as_real(), b->as_real()));
     }
   }
 


### PR DESCRIPTION
Current division operators perform so called flooring division when both
of the operands are integers, resulting in inconsistensies like

    10 3 /      #=> 1
    10 3.0 /    #=> 3.33333
    10 3 %      #=> 0
    10 3.0 %    #=> 1

Solution is to ditch the flooring division and always use real division
instead, just like JavaScript and Python 3 does.