### PR TITLE
Add maximum line length to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ trim_trailing_whitespace = true
 [*.{cpp,hpp,pl,plorth}]
 indent_style = space
 indent_size = 2
+max_line_length = 79
 
 [CMakeLists.txt]
 indent_style = space


### PR DESCRIPTION
Editor config is currently missing maximum line length setting, which should be 79. Fixes #20.