### PR TITLE
Add support for exponential notation

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -105,6 +105,7 @@ namespace plorth
     const auto length = input.length();
     unistring::size_type start;
     bool dot_seen = false;
+    bool exponent_seen = false;
 
     if (!length)
     {
@@ -128,11 +129,26 @@ namespace plorth
 
       if (c == '.')
       {
-        if (dot_seen || i == start || i + 1 > length)
+        if (dot_seen || exponent_seen || i == start || i + 1 > length)
         {
           return false;
         }
         dot_seen = true;
+      }
+      else if (c == 'e' || c == 'E')
+      {
+        if (exponent_seen || i == start || i + 2 > length)
+        {
+          return false;
+        }
+        if (input[i + 1] == '+' || input[i + 1] == '-')
+        {
+          if (i + 3 > length) {
+            return false;
+          }
+          ++i;
+        }
+        exponent_seen = true;
       }
       else if (!std::isdigit(c))
       {
@@ -298,27 +314,12 @@ namespace plorth
     // Parse exponent.
     if (offset < length && (input[offset] == 'e' || input[offset] == 'E'))
     {
-      exponent = to_integer(input.substr(offset + 1));
+      exponent += to_integer(input.substr(offset + 1));
     }
 
     if (number == 0.0)
     {
       return 0.0;
-    }
-
-    if (exponent < 0)
-    {
-      if (number < DBL_MIN * std::pow(10.0, static_cast<double>(-exponent)))
-      {
-        return NAN; // Float underflow.
-      }
-    }
-    else if (exponent > 0)
-    {
-      if (number > DBL_MAX * std::pow(10.0, static_cast<double>(exponent)))
-      {
-        return NAN; // Float overflow.
-      }
     }
 
     number *= std::pow(10.0, static_cast<double>(exponent));

--- a/src/value-number.cpp
+++ b/src/value-number.cpp
@@ -158,10 +158,25 @@ namespace plorth
   ref<class number> runtime::number(const unistring& value)
   {
     const auto dot_index = value.find('.');
+    const auto exponent_index_lower_case = value.find('e');
+    const auto exponent_index_upper_case = value.find('E');
 
-    if (dot_index == unistring::npos)
+    if (
+      dot_index == unistring::npos &&
+      exponent_index_lower_case == unistring::npos &&
+      exponent_index_upper_case == unistring::npos
+    )
     {
-      return number(to_integer(value));
+      std::int64_t result = to_integer(value);
+      if (result == false)
+      {
+        double big_result = to_real(value);
+        if (big_result != result)
+        {
+          return number(big_result);
+        }
+      }
+      return number(result);
     } else {
       return number(to_real(value));
     }

--- a/tests/test-number.plorth
+++ b/tests/test-number.plorth
@@ -33,3 +33,26 @@ test-case
   # ( -3 2 % 1 = ),  # => -1, fails compared to Python's convention.
 ]
 test-case
+
+"exponential-notation"
+[
+  ( 100000000000000000000 0 > ),
+  ( 1000000000000000000e2 1e20 = ),
+  ( 1e1 10 = ),
+  ( 4e+2 400 = ),
+  ( 5e-1 0.5 = ),
+  ( 1 25e-2 / 4 = ),
+  ( 1.5e1 15 = ),
+  ( 1.25e2 125 = ),
+  ( -1.234E-5 -1 > ),
+  ( 1e20 >source compile call +1e+20 = ),
+  ( 1e1000 1 > ),
+  ( 1e-1000 1 < ),
+  ( ( 1e ) ( nop ) try error? nip ),
+  ( ( 1e+ ) ( nop ) try error? nip ),
+  ( ( 1e-- ) ( nop ) try error? nip ),
+  ( ( 1e1.1 ) ( nop ) try error? nip ),
+  # ( 10000000000 dup * 1e19 > ),  #  fails due to overflow in *
+  # ( 8000000000000000000 dup + 1e19 > ),  # fails due to overflow in +
+]
+test-case


### PR DESCRIPTION
Make sure that numbers in exponential notation are recognized and parsed correctly.
Remove checks for floating point underflow and overflow. Those are known as 0 and inf respectively.