### PR TITLE
Fix indexing problem with zero sized containers

### DIFF
--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -981,6 +981,7 @@ namespace plorth
 
     if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
+      const auto size = ary->size();
       std::int64_t index = num->as_int();
 
       if (index < 0)
@@ -990,7 +991,7 @@ namespace plorth
 
       ctx->push(ary);
 
-      if (index < 0 || index > static_cast<std::int64_t>(ary->size()))
+      if (!size || index < 0 || index > static_cast<std::int64_t>(size))
       {
         ctx->error(error::code_range, U"Array index out of bounds.");
         return;
@@ -1038,7 +1039,7 @@ namespace plorth
         result.push_back(ary->at(i));
       }
 
-      if (index < 0 || index > static_cast<std::int64_t>(size))
+      if (!size || index < 0 || index > static_cast<std::int64_t>(size))
       {
         result.push_back(val);
       } else {

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -918,7 +918,7 @@ namespace plorth
 
       ctx->push(str);
 
-      if (index < 0 || index > static_cast<std::int64_t>(length))
+      if (!length || index < 0 || index > static_cast<std::int64_t>(length))
       {
         ctx->error(error::code_range, U"String index out of bounds.");
         return;

--- a/tests/test-array.plorth
+++ b/tests/test-array.plorth
@@ -132,6 +132,7 @@ test-case
   ( -1 [1, 2, 3] @ nip 3 = ),
   ( -2 [1, 2, 3] @ nip 2 = ),
   ( 2 [1, 2, 3] @ nip 3 = ),
+  ( ( 0 [] @ ) ( drop true ) ( false ) try-else nip ),
 ]
 test-case
 
@@ -141,5 +142,6 @@ test-case
   ( "foo" -1 [1, 2, 3] ! [1, 2, "foo"] = ),
   ( "foo" -2 [1, 2, 3] ! [1, "foo", 3] = ),
   ( "foo" 2 [1, 2, 3] ! [1, 2, "foo"] = ),
+  ( "foo" 0 [] ! ["foo"] = ),
 ]
 test-case

--- a/tests/test-string.plorth
+++ b/tests/test-string.plorth
@@ -135,5 +135,6 @@ test-case
 [
   ( 0 "foo" @ "f" = nip ),
   ( -1 "foo" @ "o" = nip ),
+  ( ( 0 "" @ ) ( drop true ) ( false ) try-else nip ),
 ]
 test-case


### PR DESCRIPTION
Due to the weird way array and string indices are tested in Plorth, it's
possible to segfault the interpreter by retrieving item 0 (or any other
index actually) from empty array or string. These modifications prevent
that and add the problematic operations into test cases.