### PR TITLE
Add push and pop words to array prototype

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -913,6 +913,39 @@ array from values returned by the quote.
 
 ---
 
+### pop
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>array</dd>
+  <dt>Gives:</dt>
+  <dd>array, any</dd>
+</dl>
+
+Removes last element from the array and places it onto the stack.
+
+
+    [1, 2, 3] pop  #=> [1, 2] 3
+
+---
+
+### push
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>any, array</dd>
+  <dt>Gives:</dt>
+  <dd>array</dd>
+</dl>
+
+Constructs new array where first value has been pushed as the last element
+of the existing array.
+
+
+    4 [1, 2, 3] push  #=> [1, 2, 3, 4]
+
+---
+
 ### reduce
 
 <dl>

--- a/tests/test-array.plorth
+++ b/tests/test-array.plorth
@@ -7,6 +7,20 @@
 ]
 test-case
 
+"push"
+[
+  ( 1 [] push [1] = ),
+  ( 3 [1, 2] push [1, 2, 3] = ),
+]
+test-case
+
+"pop"
+[
+  ( [1, 2] pop 2 = swap [1] = and ),
+  ( ( [] pop ) ( drop true ) ( false ) try-else ),
+]
+test-case
+
 "includes?"
 [
   ( 2 [1, 2, 3] includes? nip ),


### PR DESCRIPTION
Introduce two new words, `push` and `pop` into array prototype which
allows use of arrays as they were additional data stacks.