### PR TITLE
Add dip and 2dip words to quote prototype

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1503,6 +1503,21 @@ that inherited properties are not included in the list.
 
 ---
 
+### 2dip
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>any, any, quote</dd>
+  <dt>Gives:</dt>
+  <dd>any, any</dd>
+</dl>
+
+Temporarily hides two given values from the stack and calls given quote.
+Once the quote has returned from it's execution, hidden values will be
+placed back on the stack.
+
+---
+
 ### call
 
 <dl>
@@ -1538,6 +1553,21 @@ Constructs a new quote which will call the two given quotes in sequence.
 
 Constructs a curried quote where given value will be pushed onto the stack
 before calling the original quote.
+
+---
+
+### dip
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>any, quote</dd>
+  <dt>Gives:</dt>
+  <dd>any</dd>
+</dl>
+
+Temporarily hides given value from the stack and calls given quote. Once
+the quote has returned from it's execution, hidden value will be placed
+back on the stack.
 
 ---
 

--- a/src/value-quote.cpp
+++ b/src/value-quote.cpp
@@ -794,6 +794,69 @@ namespace plorth
     }
   }
 
+  /**
+   * Word: dip
+   * Prototype: quote
+   *
+   * Takes:
+   * - any
+   * - quote
+   *
+   * Gives:
+   * - any
+   *
+   * Temporarily hides given value from the stack and calls given quote. Once
+   * the quote has returned from it's execution, hidden value will be placed
+   * back on the stack.
+   */
+  static void w_dip(const ref<context>& ctx)
+  {
+    ref<value> val;
+    ref<quote> quo;
+
+    if (!ctx->pop_quote(quo) || !ctx->pop(val))
+    {
+      return;
+    }
+
+    quo->call(ctx);
+    ctx->push(val);
+  }
+
+  /**
+   * Word: 2dip
+   * Prototype: quote
+   *
+   * Takes:
+   * - any
+   * - any
+   * - quote
+   *
+   * Gives:
+   * - any
+   * - any
+   *
+   *
+   * Temporarily hides two given values from the stack and calls given quote.
+   * Once the quote has returned from it's execution, hidden values will be
+   * placed back on the stack.
+   */
+  static void w_2dip(const ref<context>& ctx)
+  {
+    ref<value> val1;
+    ref<value> val2;
+    ref<quote> quo;
+
+    if (!ctx->pop_quote(quo) || !ctx->pop(val2) || !ctx->pop(val1))
+    {
+      return;
+    }
+
+    quo->call(ctx);
+    ctx->push(val1);
+    ctx->push(val2);
+  }
+
   namespace api
   {
     runtime::prototype_definition quote_prototype()
@@ -803,7 +866,9 @@ namespace plorth
         { U"call", w_call },
         { U"compose", w_compose },
         { U"curry", w_curry },
-        { U"negate", w_negate }
+        { U"negate", w_negate },
+        { U"dip", w_dip },
+        { U"2dip", w_2dip }
       };
     }
   }

--- a/tests/test-quote.plorth
+++ b/tests/test-quote.plorth
@@ -34,3 +34,15 @@ test-case
   ( ( true ) negate call not ),
 ]
 test-case
+
+"dip"
+[
+  ( "foo" ( depth 1 = ) dip "foo" = and ),
+]
+test-case
+
+"2dip"
+[
+  ( "foo" "bar" ( depth 1 = ) 2dip "bar" = swap "foo" = and and ),
+]
+test-case


### PR DESCRIPTION
Introduce two words into quote prototype inspired by the Factor programming
language: dip and 2dip. These words can be used to call quotes with "hidden"
values that will be placed back onto the stack once the quote execution has been
completed.