### PR TITLE
Fix constants

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -983,7 +983,7 @@ namespace plorth
 
     if (ctx->pop_string(id) && ctx->pop(val))
     {
-      ctx->dictionary()[id->to_string()] = val;
+      ctx->dictionary()[id->to_string()] = ctx->runtime()->compiled_quote({ val });
     }
   }
 


### PR DESCRIPTION
Constants are currently broken. If you place quote into local dictionary
as constant, the quote will be called instead of placed onto the stack
when you access it.