### PR TITLE
Fix prototype inheritance for builtin prototypes

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -45,7 +45,10 @@ namespace plorth
     runtime::prototype_definition word_prototype();
   }
 
-  static inline ref<object> make_prototype(runtime*, const char32_t*, const runtime::prototype_definition&);
+  static inline ref<object> make_prototype(runtime*,
+                                           const char32_t*,
+                                           const ref<object>&,
+                                           const runtime::prototype_definition&);
 
   runtime::runtime(memory::manager* memory_manager)
     : m_memory_manager(memory_manager)
@@ -60,15 +63,60 @@ namespace plorth
       m_dictionary[entry.first] = native_quote(entry.second);
     }
 
-    m_object_prototype = make_prototype(this, U"object", api::object_prototype());
-    m_array_prototype = make_prototype(this, U"array", api::array_prototype());
-    m_boolean_prototype = make_prototype(this, U"boolean", api::boolean_prototype());
-    m_error_prototype = make_prototype(this, U"error", api::error_prototype());
-    m_number_prototype = make_prototype(this, U"number", api::number_prototype());
-    m_quote_prototype = make_prototype(this, U"quote", api::quote_prototype());
-    m_string_prototype = make_prototype(this, U"string", api::string_prototype());
-    m_symbol_prototype = make_prototype(this, U"symbol", api::symbol_prototype());
-    m_word_prototype = make_prototype(this, U"word", api::word_prototype());
+    m_object_prototype = make_prototype(
+      this,
+      U"object",
+      ref<object>(),
+      api::object_prototype()
+    );
+    m_array_prototype = make_prototype(
+      this,
+      U"array",
+      ref<object>(),
+      api::array_prototype()
+    );
+    m_boolean_prototype = make_prototype(
+      this,
+      U"boolean",
+      ref<object>(),
+      api::boolean_prototype()
+    );
+    m_error_prototype = make_prototype(
+      this,
+      U"error",
+      ref<object>(),
+      api::error_prototype()
+    );
+    m_number_prototype = make_prototype(
+      this,
+      U"number",
+      ref<object>(),
+      api::number_prototype()
+    );
+    m_quote_prototype = make_prototype(
+      this,
+      U"quote",
+      ref<object>(),
+      api::quote_prototype()
+    );
+    m_string_prototype = make_prototype(
+      this,
+      U"string",
+      ref<object>(),
+      api::string_prototype()
+    );
+    m_symbol_prototype = make_prototype(
+      this,
+      U"symbol",
+      ref<object>(),
+      api::symbol_prototype()
+    );
+    m_word_prototype = make_prototype(
+      this,
+      U"word",
+      ref<object>(),
+      api::word_prototype()
+    );
   }
 
   ref<context> runtime::new_context()
@@ -100,6 +148,7 @@ namespace plorth
 
   static inline ref<object> make_prototype(class runtime* runtime,
                                            const char32_t* name,
+                                           const ref<object>& parent_prototype,
                                            const runtime::prototype_definition& definition)
   {
     object::container_type properties;
@@ -109,10 +158,11 @@ namespace plorth
     {
       properties[entry.first] = runtime->native_quote(entry.second);
     }
-    properties[U"prototype"] = runtime->object_prototype();
+    properties[U"__proto__"] = parent_prototype;
 
     prototype = runtime->value<object>(properties);
     runtime->dictionary()[name] = runtime->value<object>(object::container_type({
+      { U"__proto__", runtime->object_prototype() },
       { U"prototype", prototype }
     }));
 


### PR DESCRIPTION
Not every builtin prototype should inherit directly from `object`
prototype, even though even that doesn't work properly as name of the
property of parent prototype should be `__proto__` instead of `prototype`.

Prototype of prototypes should however be `object`, which is currently
isn't. Fix that as well.