### PR TITLE
Allow only quotes in dictionaries

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -40,6 +40,7 @@ namespace plorth
   {
   public:
     using container_type = std::deque<ref<value>>;
+    using dictionary_type = std::unordered_map<unistring, ref<quote>>;
 
     /**
      * Constructs new context.
@@ -92,7 +93,7 @@ namespace plorth
     /**
      * Returns the dictionary used by this context to store words.
      */
-    inline object::container_type& dictionary()
+    inline dictionary_type& dictionary()
     {
       return m_dictionary;
     }
@@ -100,7 +101,7 @@ namespace plorth
     /**
      * Returns the dictionary used by this context to store words.
      */
-    inline const object::container_type& dictionary() const
+    inline const dictionary_type& dictionary() const
     {
       return m_dictionary;
     }
@@ -368,7 +369,7 @@ namespace plorth
     /** Data stack used for storing values in this context. */
     container_type m_data;
     /** Container for words associated with this context. */
-    object::container_type m_dictionary;
+    dictionary_type m_dictionary;
   };
 }
 

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -42,6 +42,7 @@ namespace plorth
   {
   public:
     using prototype_definition = std::vector<std::pair<const char32_t*, quote::callback>>;
+    using dictionary_type = std::unordered_map<unistring, ref<quote>>;
 
     /**
      * Constructs new runtime.
@@ -66,7 +67,16 @@ namespace plorth
      * This non-constant version of the method can be used to define new words
      * into the global dictionary, or remove existing ones.
      */
-    inline object::container_type& dictionary()
+    inline dictionary_type& dictionary()
+    {
+      return m_dictionary;
+    }
+
+    /**
+     * Returns the global dictionary that contains core word set available to
+     * all contexts.
+     */
+    inline const dictionary_type& dictionary() const
     {
       return m_dictionary;
     }
@@ -103,15 +113,6 @@ namespace plorth
     inline const std::vector<unistring>& module_paths() const
     {
       return m_module_paths;
-    }
-
-    /**
-     * Returns the global dictionary that contains core word set available to
-     * all contexts.
-     */
-    inline const object::container_type& dictionary() const
-    {
-      return m_dictionary;
     }
 
     /**
@@ -331,7 +332,7 @@ namespace plorth
     /** Memory manager associated with this runtime. */
     memory::manager* m_memory_manager;
     /** Global dictionary available to all contexts. */
-    object::container_type m_dictionary;
+    dictionary_type m_dictionary;
     /** Shared instance of true boolean value. */
     ref<class boolean> m_true_value;
     /** Shared instance of false boolean value. */

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -1005,7 +1005,13 @@ namespace plorth
    */
   static void w_globals(const ref<context>& ctx)
   {
-    ctx->push_object(ctx->runtime()->dictionary());
+    object::container_type result;
+
+    for (const auto& entry : ctx->runtime()->dictionary())
+    {
+      result[entry.first] = entry.second;
+    }
+    ctx->push_object(result);
   }
 
   /**
@@ -1018,7 +1024,13 @@ namespace plorth
    */
   static void w_locals(const ref<context>& ctx)
   {
-    ctx->push_object(ctx->dictionary());
+    object::container_type result;
+
+    for (const auto& entry : ctx->dictionary())
+    {
+      result[entry.first] = entry.second;
+    }
+    ctx->push_object(result);
   }
 
   /**

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -77,6 +77,7 @@ namespace plorth
         unistring source;
         ref<quote> compiled_module;
         ref<context> module_context;
+        object::container_type result;
 
         is.close();
 
@@ -108,7 +109,11 @@ namespace plorth
         }
 
         // TODO: Add some kind of way to selectively export words from a module.
-        module = value<object>(module_context->dictionary());
+        for (const auto& entry : module_context->dictionary())
+        {
+          result[entry.first] = entry.second;
+        }
+        module = value<object>(result);
         m_imported_modules[resolved_path] = module;
       } else {
         ctx->error(error::code_import, U"Unable to import `" + resolved_path + U"'");
@@ -121,7 +126,10 @@ namespace plorth
     // context.
     for (const auto& property : module->properties())
     {
-      ctx->dictionary()[property.first] = property.second;
+      if (property.second && property.second->is(value::type_quote))
+      {
+        ctx->dictionary()[property.first] = property.second.cast<quote>();
+      }
     }
 
     return true;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -159,12 +159,19 @@ namespace plorth
       properties[entry.first] = runtime->native_quote(entry.second);
     }
     properties[U"__proto__"] = parent_prototype;
-
     prototype = runtime->value<object>(properties);
-    runtime->dictionary()[name] = runtime->value<object>(object::container_type({
-      { U"__proto__", runtime->object_prototype() },
-      { U"prototype", prototype }
-    }));
+
+    // Define prototype into global dictionary as constant if name has been
+    // given.
+    if (name)
+    {
+      runtime->dictionary()[name] = runtime->compiled_quote({
+        runtime->value<object>(object::container_type({
+          { U"__proto__", runtime->object_prototype() },
+          { U"prototype", prototype }
+        }))
+      });
+    }
 
     return prototype;
   }

--- a/src/value-symbol.cpp
+++ b/src/value-symbol.cpp
@@ -45,8 +45,6 @@ namespace plorth
 
   bool symbol::exec(const ref<context>& ctx)
   {
-    ref<class value> value;
-
     // Look from prototype of the current item.
     {
       const auto& stack = ctx->data();
@@ -54,14 +52,15 @@ namespace plorth
       if (!stack.empty() && stack.back())
       {
         const ref<object> prototype = stack.back()->prototype(ctx->runtime());
+        ref<value> val;
 
-        if (prototype && prototype->property(ctx->runtime(), m_id, value))
+        if (prototype && prototype->property(ctx->runtime(), m_id, val))
         {
-          if (value && value->is(value::type_quote))
+          if (val && val->is(value::type_quote))
           {
-            return value.cast<quote>()->call(ctx);
+            return val.cast<quote>()->call(ctx);
           }
-          ctx->push(value);
+          ctx->push(val);
 
           return true;
         }
@@ -73,16 +72,9 @@ namespace plorth
       const auto& local_dictionary = ctx->dictionary();
       const auto entry = local_dictionary.find(m_id);
 
-      if (entry != std::end(local_dictionary))
+      if (entry != std::end(local_dictionary) && entry->second)
       {
-        value = entry->second;
-        if (value && value->is(value::type_quote))
-        {
-          return value.cast<quote>()->call(ctx);
-        }
-        ctx->push(value);
-
-        return true;
+        return entry->second->call(ctx);
       }
     }
 
@@ -95,16 +87,9 @@ namespace plorth
       const auto& global_dictionary = ctx->runtime()->dictionary();
       const auto entry = global_dictionary.find(m_id);
 
-      if (entry != std::end(global_dictionary))
+      if (entry != std::end(global_dictionary) && entry->second)
       {
-        value = entry->second;
-        if (value && value->is(value::type_quote))
-        {
-          return value.cast<quote>()->call(ctx);
-        }
-        ctx->push(value);
-
-        return true;
+        return entry->second->call(ctx);
       }
     }
 


### PR DESCRIPTION
Modify local and global dictionaries so that they only allow quotes to be placed on them. Also fixes three possible null pointer errors.