### PR TITLE
Fix --version command line switch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ static void scan_arguments(const ref<class runtime>& runtime,
       }
       else if (!std::strcmp(arg, "--version"))
       {
-        std::cerr << "Plorth " << PLORTH_VERSION << std::endl;
+        std::cerr << "Plorth " << utf8_encode(PLORTH_VERSION) << std::endl;
         std::exit(EXIT_SUCCESS);
       }
       else if (!std::strcmp(arg, "--"))


### PR DESCRIPTION
When you write `plorth-cli --version` it currently prints out some kind of
pointer instead of the version string, because it isn't UTF-8 encoded.