### PR TITLE
Fix relative imports

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -361,6 +361,26 @@ namespace plorth
      */
     bool pop_word(ref<word>& slot);
 
+#if PLORTH_ENABLE_MODULES
+    /**
+     * Returns optional filename of the context, when the context is executed as
+     * module.
+     */
+    inline const unistring& filename() const
+    {
+      return m_filename;
+    }
+
+    /**
+     * Sets optional filename of the context, when the context is executed as
+     * module.
+     */
+    inline void filename(const unistring& fn)
+    {
+      m_filename = fn;
+    }
+#endif
+
   private:
     /** Runtime associated with this context. */
     const ref<class runtime> m_runtime;
@@ -370,6 +390,10 @@ namespace plorth
     container_type m_data;
     /** Container for words associated with this context. */
     dictionary_type m_dictionary;
+#if PLORTH_ENABLE_MODULES
+    /** Optional filename of the context, when executed as module. */
+    unistring m_filename;
+#endif
   };
 }
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,9 +6,8 @@ mkdir -p build
 cd build
 env CXXFLAGS="-Wall -Werror" cmake ..
 make
-cd ../tests
-for file in test-*.plorth
+for file in ../tests/test-*.plorth
 do
   echo $file
-  ../build/plorth-cli $file
+  ./plorth-cli $file
 done

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,9 @@ int main(int argc, char** argv)
 
       is.close();
       context->clear();
+#if PLORTH_ENABLE_MODULES
+      context->filename(utf8_decode(script_filename));
+#endif
       compile_and_run(context, source);
     } else {
       std::cerr << argv[0]

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -25,6 +25,8 @@
  */
 #include <plorth/unicode.hpp>
 
+#include "./utils.hpp"
+
 #include <cfloat>
 #include <climits>
 #include <cmath>
@@ -329,5 +331,35 @@ namespace plorth
     }
 
     return number;
+  }
+
+  unistring dirname(const unistring& path)
+  {
+    const auto length = path.length();
+    unistring::size_type index;
+
+    if (!length)
+    {
+      return unistring();
+    }
+
+    index = path.find_last_of(PLORTH_FILE_SEPARATOR);
+    // No slashes found?
+    if (index == unistring::npos)
+    {
+      return U".";
+    }
+    // Slash is the first character?
+    else if (index == 0)
+    {
+      return unistring(1, PLORTH_FILE_SEPARATOR);
+    }
+    // Slash is the last character?
+    else if (index == length - 1)
+    {
+      return dirname(path.substr(0, index - 1));
+    } else {
+      return path.substr(0, index);
+    }
   }
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -28,6 +28,12 @@
 
 #include <plorth/unicode.hpp>
 
+#if defined(_WIN32)
+# define PLORTH_FILE_SEPARATOR '\\'
+#else
+# define PLORTH_FILE_SEPARATOR '/'
+#endif
+
 namespace plorth
 {
   unistring json_stringify(const unistring&);
@@ -36,6 +42,7 @@ namespace plorth
   bool is_number(const unistring&);
   unistring to_unistring(std::int64_t);
   unistring to_unistring(double);
+  unistring dirname(const unistring&);
 }
 
 #endif /* !PLORTH_UTILS_HPP_GUARD */


### PR DESCRIPTION
Relative imports always use CWD of the interpreter process as starting
point from where to look for the module. This is incorrect, as it should
be always from directory of the script file which is currently being
executed. Refactor module search routine so that it supports this.

Fixes: #64