### PR TITLE
Rename plorth-cli executable to just plorth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,10 @@ IF(PLORTH_ENABLE_TARGET_CLI)
     plorth-cli
     plorth
   )
+  SET_TARGET_PROPERTIES(
+    plorth-cli
+    PROPERTIES OUTPUT_NAME plorth
+  )
   INSTALL(
     TARGETS
       plorth-cli

--- a/examples/array-reduce.plorth
+++ b/examples/array-reduce.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Reduce an array of integers into single value using word "reduce" with
 # operator "+".

--- a/examples/bottles-of-beer.plorth
+++ b/examples/bottles-of-beer.plorth
@@ -1,3 +1,5 @@
+#!/usr/bin/env plorth
+
 : describe
   dup 1 > (dup >string " bottles" +) if
   dup 1 = ("1 bottle") if

--- a/examples/combinators.plorth
+++ b/examples/combinators.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Implement the Turing complete SKI combinator calculus in Plorth.
 # It lacks lazy evaluation features so it's not really that useful.

--- a/examples/factorial.plorth
+++ b/examples/factorial.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Declare the factorial function recursively.
 : factorial

--- a/examples/fibonacci.plorth
+++ b/examples/fibonacci.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Print the first few Fibonacci numbers
 

--- a/examples/hello-world.plorth
+++ b/examples/hello-world.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Declare word "hello-world".
 : hello-world

--- a/examples/mandelbrot.plorth
+++ b/examples/mandelbrot.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Mandelbrot fractal renderer with command line arguments for image size
 

--- a/examples/object-immutability.plorth
+++ b/examples/object-immutability.plorth
@@ -1,4 +1,4 @@
-#!/usr/bin/env plorth-cli
+#!/usr/bin/env plorth
 
 # Demonstrate object immutability
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -9,5 +9,5 @@ make
 for file in ../tests/test-*.plorth
 do
   echo $file
-  ./plorth-cli $file
+  ./plorth $file
 done


### PR DESCRIPTION
The real reason why name of Plorth interpreter is currently `plorth-cli`
is because I want to separate the interpreter library and executable.
CMake cannot handle targets with the same name, so I cannot have both
library and executable called `plorth`. However, you can override the
executable name with this simple trick which gives us both library and
executable with the same name.