### PR TITLE
Optimize reversed containers

### DIFF
--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -160,6 +160,29 @@ namespace plorth
       const size_type m_offset;
       const size_type m_size;
     };
+
+    /**
+     * Array implementation which reverses already existing array.
+     */
+    class reversed_array : public array
+    {
+    public:
+      explicit reversed_array(const ref<class array>& array)
+        : m_array(array) {}
+
+      size_type size() const
+      {
+        return m_array->size();
+      }
+
+      const_reference at(size_type offset) const
+      {
+        return m_array->at(size() - offset - 1);
+      }
+
+    private:
+      const ref<array> m_array;
+    };
   }
 
   bool array::equals(const ref<value>& that) const
@@ -620,15 +643,7 @@ namespace plorth
 
     if (ctx->pop_array(ary))
     {
-      const auto size = ary->size();
-      std::vector<ref<value>> result;
-
-      result.reserve(size);
-      for (array::size_type i = ary->size(); i > 0; --i)
-      {
-        result.push_back(ary->at(i - 1));
-      }
-      ctx->push_array(result.data(), size);
+      ctx->push(ctx->runtime()->value<reversed_array>(ary));
     }
   }
 

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -125,6 +125,29 @@ namespace plorth
       const size_type m_offset;
       const size_type m_length;
     };
+
+    /**
+     * Implementation of string which reverses already existing string.
+     */
+    class reversed_string : public string
+    {
+    public:
+      explicit reversed_string(const ref<string>& original)
+        : m_original(original) {}
+
+      size_type length() const
+      {
+        return m_original->length();
+      }
+
+      value_type at(size_type offset) const
+      {
+        return m_original->at(length() - offset - 1);
+      }
+
+    private:
+      const ref<string> m_original;
+    };
   }
 
   bool string::equals(const ref<class value>& that) const
@@ -515,14 +538,7 @@ namespace plorth
 
     if (ctx->pop_string(str))
     {
-      const auto length = str->length();
-      unichar result[length];
-
-      for (string::size_type i = length; i > 0; --i)
-      {
-        result[length - i] = str->at(i - 1);
-      }
-      ctx->push_string(result, length);
+      ctx->push(ctx->runtime()->value<reversed_string>(str));
     }
   }
 


### PR DESCRIPTION
Add implementations of reversed arrays and strings that can be used when
word `reverse` is applied to array or string, which hopefully reduces
memory usage especially when the containers are large.