### PR TITLE
Add option to use 32-bit integers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ OPTION(
 )
 
 OPTION(
+  PLORTH_ENABLE_32BIT_INT
+  "Enable if you want to use 32-bit integers instead of 64-bit."
+  OFF
+)
+
+OPTION(
   PLORTH_ENABLE_GC_DEBUG
   "Display debug messages from garbage collector."
   OFF

--- a/include/plorth/config.hpp.in
+++ b/include/plorth/config.hpp.in
@@ -34,6 +34,7 @@
 #cmakedefine PLORTH_ENABLE_SYMBOL_CACHE 1
 #cmakedefine PLORTH_ENABLE_INTEGER_CACHE 1
 #cmakedefine PLORTH_ENABLE_MEMORY_POOL 1
+#cmakedefine PLORTH_ENABLE_32BIT_INT 1
 #cmakedefine PLORTH_ENABLE_GC_DEBUG 1
 
 // Optional headers.

--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -176,12 +176,12 @@ namespace plorth
     /**
      * Pushes integer number value into the data stack.
      */
-    void push_int(std::int64_t value);
+    void push_int(number::int_type value);
 
     /**
      * Pushes real number value into the data stack.
      */
-    void push_real(double value);
+    void push_real(number::real_type value);
 
     /**
      * Pushes either integer or real number into stack, based on the given text

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -158,7 +158,7 @@ namespace plorth
      * \param value Value of the number.
      * \return      Reference to the created number value.
      */
-    ref<class number> number(std::int64_t value);
+    ref<class number> number(number::int_type value);
 
     /**
      * Constructs real number from given value.
@@ -166,7 +166,7 @@ namespace plorth
      * \param value Value of the number.
      * \return      Reference to the created number value.
      */
-    ref<class number> number(double value);
+    ref<class number> number(number::real_type value);
 
     /**
      * Parses given text input into number (either real or integer) and

--- a/include/plorth/value-number.hpp
+++ b/include/plorth/value-number.hpp
@@ -33,6 +33,18 @@ namespace plorth
   class number : public value
   {
   public:
+#if PLORTH_ENABLE_32BIT_INT
+    using int_type = std::int32_t;
+#else
+    using int_type = std::int64_t;
+#endif
+    using real_type = double;
+
+    static const int_type int_min;
+    static const int_type int_max;
+    static const real_type real_min;
+    static const real_type real_max;
+
     /**
      * Enumeration for different supported number types.
      */
@@ -58,12 +70,12 @@ namespace plorth
     /**
      * Returns value of the number as integer.
      */
-    virtual std::int64_t as_int() const = 0;
+    virtual int_type as_int() const = 0;
 
     /**
      * Returns value of the number as floating point decimal.
      */
-    virtual double as_real() const = 0;
+    virtual real_type as_real() const = 0;
 
     inline enum type type() const
     {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -48,12 +48,12 @@ namespace plorth
     push(m_runtime->boolean(value));
   }
 
-  void context::push_int(std::int64_t value)
+  void context::push_int(number::int_type value)
   {
     push(m_runtime->number(value));
   }
 
-  void context::push_real(double value)
+  void context::push_real(number::real_type value)
   {
     push(m_runtime->number(value));
   }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -889,7 +889,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      const std::int64_t size = num->as_int();
+      const number::int_type size = num->as_int();
       ref<value>* buffer;
 
       if (size < 0)
@@ -900,7 +900,7 @@ namespace plorth
 
       buffer = new ref<value>[size];
 
-      for (std::int64_t i = 0; i < size; ++i)
+      for (number::int_type i = 0; i < size; ++i)
       {
         ref<value> val;
 
@@ -1357,7 +1357,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      std::int64_t c = num->as_int();
+      number::int_type c = num->as_int();
 
       if (!unichar_validate(c))
       {

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -35,7 +35,7 @@ static void w_stack(const ref<context>& ctx)
   {
     const auto& value = stack[size - i - 1];
 
-    runtime->print(to_unistring(static_cast<std::int64_t>(size - i)) + U": ");
+    runtime->print(to_unistring(static_cast<number::int_type>(size - i)) + U": ");
     runtime->print(value ? value->to_source() : U"null");
     runtime->println();
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,6 +33,12 @@
 
 namespace plorth
 {
+#if PLORTH_ENABLE_32BIT_INT
+  using uint_type = std::uint32_t;
+#else
+  using uint_type = std::uint64_t;
+#endif
+
   static const char digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
   static const unistring unistring_nan = {'n', 'a', 'n'};
   static const unistring unistring_inf = {'i', 'n', 'f'};
@@ -161,10 +167,10 @@ namespace plorth
     return true;
   }
 
-  unistring to_unistring(std::int64_t number)
+  unistring to_unistring(number::int_type number)
   {
     const bool negative = number < 0;
-    std::uint64_t mag = static_cast<std::uint64_t>(negative ? -number : number);
+    uint_type mag = static_cast<uint_type>(negative ? -number : number);
     unistring result;
 
     if (mag != 0)
@@ -187,7 +193,7 @@ namespace plorth
     return result;
   }
 
-  unistring to_unistring(double number)
+  unistring to_unistring(number::real_type number)
   {
     char buffer[20];
 
@@ -204,11 +210,11 @@ namespace plorth
     return utf8_decode(buffer);
   }
 
-  std::int64_t to_integer(const unistring& input)
+  number::int_type to_integer(const unistring& input)
   {
-    static const std::int64_t div = INT64_MAX / 10;
-    static const std::int64_t rem = INT64_MAX % 10;
-    std::int64_t number = 0;
+    static const number::int_type div = number::int_max / 10;
+    static const number::int_type rem = number::int_max % 10;
+    number::int_type number = 0;
     const std::size_t length = input.length();
     std::size_t offset;
     bool sign;
@@ -243,15 +249,15 @@ namespace plorth
     return sign ? number : -number;
   }
 
-  double to_real(const unistring& input)
+  number::real_type to_real(const unistring& input)
   {
     const auto length = input.length();
-    double number;
+    number::real_type number;
     unistring::size_type offset;
     bool seen_digits = false;
     bool seen_dot = false;
     bool sign;
-    std::int64_t exponent = 0;
+    number::int_type exponent = 0;
 
     if (!length)
     {
@@ -289,7 +295,7 @@ namespace plorth
       if (std::isdigit(c))
       {
         seen_digits = true;
-        if (number > DBL_MAX * 0.1)
+        if (number > number::real_max * 0.1)
         {
           ++exponent;
         } else {
@@ -324,7 +330,7 @@ namespace plorth
       return 0.0;
     }
 
-    number *= std::pow(10.0, static_cast<double>(exponent));
+    number *= std::pow(10.0, static_cast<number::real_type>(exponent));
     if (!sign)
     {
       number = -number;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -26,7 +26,7 @@
 #ifndef PLORTH_UTILS_HPP_GUARD
 #define PLORTH_UTILS_HPP_GUARD
 
-#include <plorth/unicode.hpp>
+#include <plorth/value-number.hpp>
 
 #if defined(_WIN32)
 # define PLORTH_FILE_SEPARATOR '\\'
@@ -37,11 +37,11 @@
 namespace plorth
 {
   unistring json_stringify(const unistring&);
-  std::int64_t to_integer(const unistring&);
-  double to_real(const unistring&);
+  number::int_type to_integer(const unistring&);
+  number::real_type to_real(const unistring&);
   bool is_number(const unistring&);
-  unistring to_unistring(std::int64_t);
-  unistring to_unistring(double);
+  unistring to_unistring(number::int_type);
+  unistring to_unistring(number::real_type);
   unistring dirname(const unistring&);
 }
 

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -998,14 +998,14 @@ namespace plorth
     if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
       const auto size = ary->size();
-      const std::int64_t count = num->as_int();
+      const number::int_type count = num->as_int();
 
       if (count >= 0)
       {
         std::vector<ref<value>> result;
 
         result.reserve(size * count);
-        for (std::int64_t i = 0; i < count; ++i)
+        for (number::int_type i = 0; i < count; ++i)
         {
           for (array::size_type j = 0; j < size; ++j)
           {
@@ -1173,7 +1173,7 @@ namespace plorth
     if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
       const auto size = ary->size();
-      std::int64_t index = num->as_int();
+      number::int_type index = num->as_int();
 
       if (index < 0)
       {
@@ -1182,7 +1182,7 @@ namespace plorth
 
       ctx->push(ary);
 
-      if (!size || index < 0 || index > static_cast<std::int64_t>(size))
+      if (!size || index < 0 || index > static_cast<number::int_type>(size))
       {
         ctx->error(error::code_range, U"Array index out of bounds.");
         return;
@@ -1217,7 +1217,7 @@ namespace plorth
     if (ctx->pop_array(ary) && ctx->pop_number(num) && ctx->pop(val))
     {
       const auto size = ary->size();
-      std::int64_t index = num->as_int();
+      number::int_type index = num->as_int();
       std::vector<ref<value>> result;
 
       if (index < 0)
@@ -1230,7 +1230,7 @@ namespace plorth
         result.push_back(ary->at(i));
       }
 
-      if (!size || index < 0 || index > static_cast<std::int64_t>(size))
+      if (!size || index < 0 || index > static_cast<number::int_type>(size))
       {
         result.push_back(val);
       } else {

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -389,7 +389,7 @@ namespace plorth
       output.reserve(length);
       for (string::size_type i = 0; i < length; ++i)
       {
-        output.push_back(runtime->number(static_cast<std::int64_t>(str->at(i))));
+        output.push_back(runtime->number(static_cast<number::int_type>(str->at(i))));
       }
       ctx->push(str);
       ctx->push_array(output.data(), length);
@@ -861,7 +861,7 @@ namespace plorth
     if (ctx->pop_string(str) && ctx->pop_number(num))
     {
       const auto length = str->length();
-      std::int64_t count = num->as_int();
+      number::int_type count = num->as_int();
       unistring result;
 
       if (count < 0)
@@ -908,7 +908,7 @@ namespace plorth
     if (ctx->pop_string(str) && ctx->pop_number(num))
     {
       const auto length = str->length();
-      std::int64_t index = num->as_int();
+      number::int_type index = num->as_int();
       unichar c;
 
       if (index < 0)
@@ -918,7 +918,7 @@ namespace plorth
 
       ctx->push(str);
 
-      if (!length || index < 0 || index > static_cast<std::int64_t>(length))
+      if (!length || index < 0 || index > static_cast<number::int_type>(length))
       {
         ctx->error(error::code_range, U"String index out of bounds.");
         return;


### PR DESCRIPTION
64-bit integers in WebAssembly result in poor performance as they have
to be emulated as the platform doesn't directly support them. For this
reason, I added an option to choose between 64-bit and 32-bit integer
types, which by default uses 64-bit integers.