### PR TITLE
Reorganize header files

### DIFF
--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -33,6 +33,8 @@
 
 namespace plorth
 {
+  class word;
+
   /**
    * Represents program execution state.
    */

--- a/include/plorth/memory.hpp
+++ b/include/plorth/memory.hpp
@@ -26,14 +26,20 @@
 #ifndef PLORTH_MEMORY_HPP_GUARD
 #define PLORTH_MEMORY_HPP_GUARD
 
+#include <plorth/config.hpp>
 #include <plorth/ref.hpp>
 
 #include <cstddef>
 
 namespace plorth
 {
+  class runtime;
+
   namespace memory
   {
+    struct pool;
+    struct slot;
+
     /**
      * Memory manager manages memory pools used by the interpreter and is used
      * for allocated memory for managed objects.

--- a/include/plorth/plorth.hpp
+++ b/include/plorth/plorth.hpp
@@ -28,31 +28,17 @@
 
 #include <plorth/config.hpp>
 
-namespace plorth
-{
-  class context;
-  class runtime;
-  class token;
+#include <plorth/value.hpp>
+#include <plorth/value-array.hpp>
+#include <plorth/value-boolean.hpp>
+#include <plorth/value-error.hpp>
+#include <plorth/value-number.hpp>
+#include <plorth/value-object.hpp>
+#include <plorth/value-quote.hpp>
+#include <plorth/value-string.hpp>
+#include <plorth/value-word.hpp>
 
-  // Different types of values.
-  class array;
-  class boolean;
-  class error;
-  class number;
-  class object;
-  class quote;
-  class string;
-  class symbol;
-  class word;
-
-  namespace memory
-  {
-    struct pool;
-    struct slot;
-
-    class managed;
-    class manager;
-  }
-}
+#include <plorth/runtime.hpp>
+#include <plorth/context.hpp>
 
 #endif /* !PLORTH_PLORTH_HPP_GUARD */

--- a/include/plorth/ref.hpp
+++ b/include/plorth/ref.hpp
@@ -26,8 +26,6 @@
 #ifndef PLORTH_REF_HPP_GUARD
 #define PLORTH_REF_HPP_GUARD
 
-#include <plorth/plorth.hpp>
-
 namespace plorth
 {
   /**

--- a/include/plorth/unicode.hpp
+++ b/include/plorth/unicode.hpp
@@ -26,6 +26,8 @@
 #ifndef PLORTH_UNICODE_HPP_GUARD
 #define PLORTH_UNICODE_HPP_GUARD
 
+#include <plorth/config.hpp>
+
 #include <cstdint>
 
 #include <iostream>

--- a/include/plorth/value.hpp
+++ b/include/plorth/value.hpp
@@ -31,6 +31,9 @@
 
 namespace plorth
 {
+  class context;
+  class object;
+
   /**
    * Abstract base class for everything that acts as an value in Plorth.
    */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,8 +23,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <plorth/context.hpp>
-#include <plorth/value-quote.hpp>
+#include <plorth/plorth.hpp>
 
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
Include required predeclarations and includes into header files so that
they can be either included individually as is done now, or so that the
`plorth/plorth.hpp` header can be the only header needed to include to
embed the interpreter into C++ application.