### PR TITLE
Use C++11 API for epoch retrieval

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -26,7 +26,7 @@
 #include <plorth/context.hpp>
 
 #include <cmath>
-#include <ctime>
+#include <chrono>
 
 namespace plorth
 {
@@ -1379,7 +1379,9 @@ namespace plorth
    */
   static void w_now(const ref<context>& ctx)
   {
-    ctx->push_int(std::time(nullptr));
+    const auto timestamp = std::chrono::system_clock::now().time_since_epoch();
+
+    ctx->push_int(std::chrono::duration_cast<std::chrono::seconds>(timestamp).count());
   }
 
   /**


### PR DESCRIPTION
While `std::time()` function usually returns number of seconds since the
epoch, the specification says that whatever this function returns is
actually implementation specific, thus it's not very portable function
to use for such purpose.

Luckily C++11 chrono API provides us function which should return number
of seconds since epoch for every platform.