### PR TITLE
Source code location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ SET(
   src/globals.cpp
   src/memory.cpp
   src/module.cpp
+  src/position.cpp
   src/runtime.cpp
   src/unicode.cpp
   src/utils.cpp

--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -81,8 +81,15 @@ namespace plorth
     /**
      * Constructs new error instance with given error code and error message
      * and replaces this execution state's currently uncaught error with it.
+     *
+     * \param code     Error code
+     * \param message  Textual description of the error
+     * \param position Optional position in the source code where the error
+     *                 occurred
      */
-    void error(enum error::code code, const unistring& message);
+    void error(enum error::code code,
+               const unistring& message,
+               const struct position* position = nullptr);
 
     /**
      * Removes currently uncaught error in the context.
@@ -111,11 +118,14 @@ namespace plorth
     /**
      * Compiles given source code into a quote.
      *
-     * \param source Source code to compile into quote.
-     * \return       Reference the quote that was compiled from given source,
-     *               or null reference if syntax error was encountered.
+     * \param source   Source code to compile into quote.
+     * \param filename Optional file name information from which the source
+     *                 code was read from.
+     * \return         Reference the quote that was compiled from given source,
+     *                 or null reference if syntax error was encountered.
      */
-    ref<quote> compile(const unistring& source);
+    ref<quote> compile(const unistring& source,
+                       const unistring& filename = U"");
 
     /**
      * Provides direct access to the data stack.

--- a/include/plorth/position.hpp
+++ b/include/plorth/position.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PLORTH_POSITION_HPP_GUARD
+#define PLORTH_POSITION_HPP_GUARD
+
+#include <plorth/unicode.hpp>
+
+namespace plorth
+{
+  /**
+   * Represents position in source code.
+   */
+  struct position
+  {
+    unistring filename;
+    int line;
+    int column;
+  };
+}
+
+#endif /* !PLORTH_POSITION_HPP_GUARD */

--- a/include/plorth/value-error.hpp
+++ b/include/plorth/value-error.hpp
@@ -26,6 +26,7 @@
 #ifndef PLORTH_VALUE_ERROR_HPP_GUARD
 #define PLORTH_VALUE_ERROR_HPP_GUARD
 
+#include <plorth/position.hpp>
 #include <plorth/value.hpp>
 
 namespace plorth
@@ -51,7 +52,19 @@ namespace plorth
       code_unknown = 100
     };
 
-    explicit error(enum code code, const unistring& message);
+    /**
+     * Constructs new error instance.
+     *
+     * \param code     Error code
+     * \param message  Textual description of the error
+     * \param position Optional position in source code where the error
+     *                 occurred.
+     */
+    explicit error(enum code code,
+                   const unistring& message,
+                   const struct position* position = nullptr);
+
+    ~error();
 
     inline enum code code() const
     {
@@ -73,6 +86,15 @@ namespace plorth
       return m_message;
     }
 
+    /**
+     * Returns position in the source code where the error occurred or null
+     * pointer if no such information is available.
+     */
+    inline const struct position* position() const
+    {
+      return m_position;
+    }
+
     inline enum type type() const
     {
       return type_error;
@@ -83,8 +105,12 @@ namespace plorth
     unistring to_source() const;
 
   private:
+    /** Error code. */
     const enum code m_code;
+    /** Textual description of the error. */
     const unistring m_message;
+    /** Optional position in source code. */
+    struct position* m_position;
   };
 
   std::ostream& operator<<(std::ostream&, enum error::code);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -39,7 +39,7 @@ namespace plorth
       {
         m_position.filename = filename;
         m_position.line = 1;
-        m_position.column = 0;
+        m_position.column = 1;
       }
 
       /**
@@ -71,7 +71,7 @@ namespace plorth
         if (result == '\n')
         {
           ++m_position.line;
-          m_position.column = 0;
+          m_position.column = 1;
         } else {
           ++m_position.column;
         }
@@ -236,6 +236,7 @@ namespace plorth
 
       ref<word> compile_word(context* ctx)
       {
+        struct position position;
         const auto& runtime = ctx->runtime();
         ref<class symbol> symbol;
         std::vector<ref<value>> values;
@@ -251,12 +252,14 @@ namespace plorth
           return ref<word>();
         }
 
+        position = m_position;
+
         if (!peek_read(':'))
         {
           ctx->error(
             error::code_syntax,
             U"Unexpected input; Missing word.",
-            &m_position
+            &position
           );
 
           return ref<word>();
@@ -274,7 +277,7 @@ namespace plorth
             ctx->error(
               error::code_syntax,
               U"Unterminated word; Missing `;'.",
-              &m_position
+              &position
             );
 
             return ref<word>();
@@ -301,6 +304,7 @@ namespace plorth
 
       ref<quote> compile_quote(context* ctx)
       {
+        struct position position;
         std::vector<ref<value>> values;
 
         if (skip_whitespace())
@@ -314,12 +318,14 @@ namespace plorth
           return ref<quote>();
         }
 
+        position = m_position;
+
         if (!peek_read('('))
         {
           ctx->error(
             error::code_syntax,
             U"Unexpected input; Missing quote.",
-            &m_position
+            &position
           );
 
           return ref<quote>();
@@ -332,7 +338,7 @@ namespace plorth
             ctx->error(
               error::code_syntax,
               U"Unterminated quote; Missing `)'.",
-              &m_position
+              &position
             );
 
             return ref<quote>();
@@ -356,6 +362,7 @@ namespace plorth
 
       ref<string> compile_string(context* ctx)
       {
+        struct position position;
         unichar separator;
         unistring buffer;
 
@@ -370,12 +377,14 @@ namespace plorth
           return ref<string>();
         }
 
+        position = m_position;
+
         if (!peek_read('"', separator) && !peek_read('\'', separator))
         {
           ctx->error(
             error::code_syntax,
             U"Unexpected input; Missing string.",
-            &m_position
+            &position
           );
 
           return ref<string>();
@@ -388,7 +397,7 @@ namespace plorth
             ctx->error(
               error::code_syntax,
               unistring(U"Unterminated string; Missing `") + separator + U"'",
-              &m_position
+              &position
             );
 
             return ref<string>();
@@ -413,6 +422,7 @@ namespace plorth
 
       ref<array> compile_array(context* ctx)
       {
+        struct position position;
         std::vector<ref<value>> elements;
 
         if (skip_whitespace())
@@ -426,12 +436,14 @@ namespace plorth
           return ref<array>();
         }
 
+        position = m_position;
+
         if (!peek_read('['))
         {
           ctx->error(
             error::code_syntax,
             U"Unexpected input; Missing array.",
-            &m_position
+            &position
           );
 
           return ref<array>();
@@ -444,7 +456,7 @@ namespace plorth
             ctx->error(
               error::code_syntax,
               U"Unterminated array; Missing `]'.",
-              &m_position
+              &position
             );
 
             return ref<array>();
@@ -465,7 +477,7 @@ namespace plorth
               ctx->error(
                 error::code_syntax,
                 U"Unterminated array; Missing `]'.",
-                &m_position
+                &position
               );
 
               return ref<array>();
@@ -480,6 +492,7 @@ namespace plorth
 
       ref<object> compile_object(context* ctx)
       {
+        struct position position;
         object::container_type properties;
 
         if (skip_whitespace())
@@ -493,12 +506,14 @@ namespace plorth
           return ref<object>();
         }
 
+        position = m_position;
+
         if (!peek_read('{'))
         {
           ctx->error(
             error::code_syntax,
             U"Unexpected input; Missing object.",
-            &m_position
+            &position
           );
 
           return ref<object>();
@@ -511,7 +526,7 @@ namespace plorth
             ctx->error(
               error::code_syntax,
               U"Unterminated object; Missing `}'.",
-              &m_position
+              &position
             );
 
             return ref<object>();
@@ -533,7 +548,7 @@ namespace plorth
               ctx->error(
                 error::code_syntax,
                 U"Unterminated object; Missing `}'.",
-                &m_position
+                &position
               );
 
               return ref<object>();
@@ -562,7 +577,7 @@ namespace plorth
               ctx->error(
                 error::code_syntax,
                 U"Unterminated object; Missing `}'.",
-                &m_position
+                &position
               );
 
               return ref<object>();
@@ -577,6 +592,8 @@ namespace plorth
 
       bool compile_escape_sequence(context* ctx, unistring& buffer)
       {
+        struct position position;
+
         if (eof())
         {
           ctx->error(
@@ -587,6 +604,8 @@ namespace plorth
 
           return false;
         }
+
+        position = m_position;
 
         switch (read())
         {
@@ -628,7 +647,7 @@ namespace plorth
                 ctx->error(
                   error::code_syntax,
                   U"Unterminated escape sequence.",
-                  &m_position
+                  &position
                 );
 
                 return false;
@@ -638,7 +657,7 @@ namespace plorth
                 ctx->error(
                   error::code_syntax,
                   U"Illegal Unicode hex escape sequence.",
-                  &m_position
+                  &position
                 );
 
                 return false;
@@ -661,7 +680,7 @@ namespace plorth
               ctx->error(
                 error::code_syntax,
                 U"Illegal Unicode hex escape sequence.",
-                &m_position
+                &position
               );
 
               return false;
@@ -675,7 +694,7 @@ namespace plorth
           ctx->error(
             error::code_syntax,
             U"Illegal escape sequence in string literal.",
-            &m_position
+            &position
           );
 
           return false;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -33,9 +33,15 @@ namespace plorth
   context::context(const ref<class runtime>& runtime)
     : m_runtime(runtime) {}
 
-  void context::error(enum error::code code, const unistring& message)
+  void context::error(enum error::code code,
+                      const unistring& message,
+                      const struct position* position)
   {
-    m_error = new (m_runtime->memory_manager()) class error(code, message);
+    m_error = new (m_runtime->memory_manager()) class error(
+      code,
+      message,
+      position
+    );
   }
 
   void context::push_null()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,10 +270,12 @@ static void handle_error(const ref<context>& ctx)
 
   if (err)
   {
-    std::cerr << "Error: "
-              << err->code()
-              << " - "
-              << err->message();
+    std::cerr << "Error: ";
+    if (err->position())
+    {
+      std::cerr << *err->position() << ':';
+    }
+    std::cerr << err->code() << " - " << err->message();
   } else {
     std::cerr << "Unknown error.";
   }
@@ -419,7 +421,13 @@ static void console_loop(const ref<class context>& context)
         }
         if (context->error())
         {
-          std::cout << context->error() << std::endl;
+          const auto& error = context->error();
+
+          if (error->position())
+          {
+            std::cout << *error->position() << ':';
+          }
+          std::cout << error << std::endl;
           context->clear_error();
         }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,9 @@ static void scan_arguments(const ref<runtime>&, int, char**);
 static void scan_module_path(const ref<runtime>&);
 #endif
 static inline bool is_console_interactive();
-static void compile_and_run(const ref<context>&, const std::string&);
+static void compile_and_run(const ref<context>&,
+                            const std::string&,
+                            const unistring&);
 static void console_loop(const ref<context>&);
 
 void initialize_repl_api(const ref<runtime>&);
@@ -70,6 +72,7 @@ int main(int argc, char** argv)
 
   if (script_filename)
   {
+    const unistring decoded_script_filename = utf8_decode(script_filename);
     std::ifstream is(script_filename, std::ios_base::in);
 
     if (is.good())
@@ -82,9 +85,9 @@ int main(int argc, char** argv)
       is.close();
       context->clear();
 #if PLORTH_ENABLE_MODULES
-      context->filename(utf8_decode(script_filename));
+      context->filename(decoded_script_filename);
 #endif
-      compile_and_run(context, source);
+      compile_and_run(context, source, decoded_script_filename);
     } else {
       std::cerr << argv[0]
                 << ": Unable to open file `"
@@ -103,8 +106,9 @@ int main(int argc, char** argv)
       std::string(
         std::istreambuf_iterator<char>(std::cin),
         std::istreambuf_iterator<char>()
-        )
-      );
+      ),
+      U"<stdin>"
+    );
   }
 
   return EXIT_SUCCESS;
@@ -277,7 +281,9 @@ static void handle_error(const ref<context>& ctx)
   std::exit(EXIT_FAILURE);
 }
 
-static void compile_and_run(const ref<context>& ctx, const std::string& input)
+static void compile_and_run(const ref<context>& ctx,
+                            const std::string& input,
+                            const unistring& filename)
 {
   unistring source;
   ref<quote> script;
@@ -288,7 +294,7 @@ static void compile_and_run(const ref<context>& ctx, const std::string& input)
     std::exit(EXIT_FAILURE);
   }
 
-  if (!(script = ctx->compile(source)))
+  if (!(script = ctx->compile(source, filename)))
   {
     handle_error(ctx);
     return;
@@ -404,7 +410,7 @@ static void console_loop(const ref<class context>& context)
       count_open_braces(line, open_braces);
       if (open_braces.empty())
       {
-        const ref<quote> script = context->compile(source);
+        const ref<quote> script = context->compile(source, U"<repl>");
 
         source.clear();
         if (script)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -126,7 +126,7 @@ namespace plorth
     }
 
     // Then attempt to compile it.
-    if (!(compiled_module = ctx->compile(source)))
+    if (!(compiled_module = ctx->compile(source, path)))
     {
       return ref<object>();
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -23,24 +23,23 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef PLORTH_POSITION_HPP_GUARD
-#define PLORTH_POSITION_HPP_GUARD
-
-#include <plorth/unicode.hpp>
+#include <plorth/position.hpp>
 
 namespace plorth
 {
-  /**
-   * Represents position in source code.
-   */
-  struct position
+  std::ostream& operator<<(std::ostream& os, const position& pos)
   {
-    unistring filename;
-    int line;
-    int column;
-  };
+    if (pos.filename.empty())
+    {
+      os << "<unknown>";
+    } else {
+      os << pos.filename;
+    }
+    if (pos.line > 0)
+    {
+      os << ':' << pos.line << ':' << pos.column;
+    }
 
-  std::ostream& operator<<(std::ostream&, const position&);
+    return os;
+  }
 }
-
-#endif /* !PLORTH_POSITION_HPP_GUARD */

--- a/src/value-error.cpp
+++ b/src/value-error.cpp
@@ -172,6 +172,47 @@ namespace plorth
   }
 
   /**
+   * Word: position
+   * Prototype: error
+   *
+   * Takes
+   * - error
+   *
+   * Gives:
+   * - error
+   * - object|null
+   *
+   * Returns position in the source code where the error occurred, or null if
+   * no such information is available.
+   *
+   * Position is returned as object with `filename`, `line` and `column`
+   * properties.
+   */
+  static void w_position(const ref<context>& ctx)
+  {
+    ref<value> err;
+
+    if (ctx->pop(err, value::type_error))
+    {
+      const auto position = err.cast<error>()->position();
+
+      ctx->push(err);
+      if (position)
+      {
+        const auto& runtime = ctx->runtime();
+
+        ctx->push_object({
+          { U"filename", runtime->string(position->filename) },
+          { U"line", runtime->number(number::int_type(position->line)) },
+          { U"column", runtime->number(number::int_type(position->column)) }
+        });
+      } else {
+        ctx->push_null();
+      }
+    }
+  }
+
+  /**
    * Word: throw
    * Prototype: error
    *
@@ -198,6 +239,7 @@ namespace plorth
       {
         { U"code", w_code },
         { U"message", w_message },
+        { U"position", w_position },
         { U"throw", w_throw },
       };
     }

--- a/src/value-error.cpp
+++ b/src/value-error.cpp
@@ -27,9 +27,20 @@
 
 namespace plorth
 {
-  error::error(enum code code, const unistring& message)
+  error::error(enum code code,
+               const unistring& message,
+               const struct position* position)
     : m_code(code)
-    , m_message(message) {}
+    , m_message(message)
+    , m_position(position ? new struct position(*position) : nullptr) {}
+
+  error::~error()
+  {
+    if (m_position)
+    {
+      delete m_position;
+    }
+  }
 
   unistring error::code_description() const
   {


### PR DESCRIPTION
Include optional source code position in errors, so that position where the error has occurred can be displayed. Currently it contains filename as well as line and column numbers.

Unfortunately this can currently be implemented only with syntax errors. Proper way to do this would be storing source code position into each symbol, which would then be transferred to interpreter when the symbol is being executed. This is not possible currently because we cache symbols to reduce resource usage.

Fixes #65 