### PR TITLE
Even more improved error reporting

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2113,6 +2113,24 @@ data stack, local dictionary and global dictionary and executes it. If the
 symbol does not resolve into any kind of word or value, number conversion
 is attempted on it. If that also fails, reference error will be thrown.
 
+---
+
+### position
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>symbol</dd>
+  <dt>Gives:</dt>
+  <dd>symbol, object|null</dd>
+</dl>
+
+Returns position in source code where the symbols was encountered, or null
+if no such information is available. If symbol caching has been enabled in
+the interpreter, source code position is not stored in symbols.
+
+Position is returnedd as object with `filename`, `line` and `column`
+properties.
+
 ## word
 
 ---

--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -393,6 +393,24 @@ namespace plorth
     }
 #endif
 
+    /**
+     * Returns reference to a structure which has information about current
+     * position in source code.
+     */
+    inline struct position& position()
+    {
+      return m_position;
+    }
+
+    /**
+     * Returns reference to a structure which has information about current
+     * position in source code.
+     */
+    inline const struct position& position() const
+    {
+      return m_position;
+    }
+
   private:
     /** Runtime associated with this context. */
     const ref<class runtime> m_runtime;
@@ -406,6 +424,8 @@ namespace plorth
     /** Optional filename of the context, when executed as module. */
     unistring m_filename;
 #endif
+    /** Current position in source code. */
+    struct position m_position;
   };
 }
 

--- a/include/plorth/context.hpp
+++ b/include/plorth/context.hpp
@@ -121,11 +121,17 @@ namespace plorth
      * \param source   Source code to compile into quote.
      * \param filename Optional file name information from which the source
      *                 code was read from.
+     * \param line     Initial line number of the source code. This is for
+     *                 debugging purposes only.
+     * \param column   Initial column number of the source code. This is for
+     *                 debugging purposes only.
      * \return         Reference the quote that was compiled from given source,
      *                 or null reference if syntax error was encountered.
      */
     ref<quote> compile(const unistring& source,
-                       const unistring& filename = U"");
+                       const unistring& filename = U"",
+                       int line = 1,
+                       int column = 1);
 
     /**
      * Provides direct access to the data stack.

--- a/include/plorth/runtime.hpp
+++ b/include/plorth/runtime.hpp
@@ -206,10 +206,13 @@ namespace plorth
     /**
      * Constructs symbol from given identifier string.
      *
-     * \param id String which acts as identifier for the symbol.
-     * \return   Reference to the created symbol.
+     * \param id       String which acts as identifier for the symbol.
+     * \param position Optional position in source code where the symbol was
+     *                 encountered.
+     * \return         Reference to the created symbol.
      */
-    ref<class symbol> symbol(const unistring& id);
+    ref<class symbol> symbol(const unistring& id,
+                             const struct position* position = nullptr);
 
     /**
      * Constructs compiled quote from given sequence of values.

--- a/include/plorth/value-symbol.hpp
+++ b/include/plorth/value-symbol.hpp
@@ -39,9 +39,17 @@ namespace plorth
     /**
      * Constructs new symbol.
      *
-     * \param id String which acts as identifier for the symbol.
+     * \param id       String which acts as identifier for the symbol.
+     * \param position Optional position in source code where the symbol was
+     *                 encountered.
      */
-    explicit symbol(const unistring& id);
+    explicit symbol(const unistring& id,
+                    const struct position* position = nullptr);
+
+    /**
+     * Destructor.
+     */
+    ~symbol();
 
     /**
      * Returns string which acts as identifier for the symbol.
@@ -49,6 +57,15 @@ namespace plorth
     inline const unistring& id() const
     {
       return m_id;
+    }
+
+    /**
+     * Returns position of the symbol in source code, or null pointer if no
+     * such information is available.
+     */
+    inline const struct position* position() const
+    {
+      return m_position;
     }
 
     inline enum type type() const
@@ -65,6 +82,8 @@ namespace plorth
   private:
     /** Identifier of the symbol. */
     const unistring m_id;
+    /** Position of the symbol in source code. */
+    struct position* m_position;
   };
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -201,6 +201,7 @@ namespace plorth
 
       ref<symbol> compile_symbol(context* ctx)
       {
+        struct position position;
         unistring buffer;
 
         if (skip_whitespace())
@@ -213,6 +214,8 @@ namespace plorth
 
           return ref<symbol>();
         }
+
+        position = m_position;
 
         if (!unichar_isword(peek()))
         {
@@ -231,7 +234,7 @@ namespace plorth
           buffer.append(1, read());
         }
 
-        return ctx->runtime()->value<symbol>(buffer);
+        return ctx->runtime()->symbol(buffer, &position);
       }
 
       ref<word> compile_word(context* ctx)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -33,13 +33,16 @@ namespace plorth
     class compiler
     {
     public:
-      explicit compiler(const unistring& source, const unistring& filename)
+      explicit compiler(const unistring& source,
+                        const unistring& filename,
+                        int line,
+                        int column)
         : m_pos(std::begin(source))
         , m_end(std::end(source))
       {
         m_position.filename = filename;
-        m_position.line = 1;
-        m_position.column = 1;
+        m_position.line = line;
+        m_position.column = column;
       }
 
       /**
@@ -751,8 +754,10 @@ namespace plorth
   }
 
   ref<quote> context::compile(const unistring& source,
-                              const unistring& filename)
+                              const unistring& filename,
+                              int line,
+                              int column)
   {
-    return compiler(source, filename).compile(this);
+    return compiler(source, filename, line, column).compile(this);
   }
 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -37,6 +37,10 @@ namespace plorth
                       const unistring& message,
                       const struct position* position)
   {
+    if (!position && (m_position.filename.empty() || m_position.line > 0))
+    {
+      position = &m_position;
+    }
     m_error = new (m_runtime->memory_manager()) class error(
       code,
       message,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -412,7 +412,11 @@ static void console_loop(const ref<class context>& context)
       count_open_braces(line, open_braces);
       if (open_braces.empty())
       {
-        const ref<quote> script = context->compile(source, U"<repl>");
+        const ref<quote> script = context->compile(
+          source,
+          U"<repl>",
+          line_counter
+        );
 
         source.clear();
         if (script)

--- a/src/value-symbol.cpp
+++ b/src/value-symbol.cpp
@@ -54,6 +54,13 @@ namespace plorth
 
   bool symbol::exec(const ref<context>& ctx)
   {
+    // Update source code position of the context, if this symbol has such
+    // information.
+    if (m_position)
+    {
+      ctx->position() = *m_position;
+    }
+
     // Look from prototype of the current item.
     {
       const auto& stack = ctx->data();

--- a/src/value-symbol.cpp
+++ b/src/value-symbol.cpp
@@ -30,8 +30,17 @@
 
 namespace plorth
 {
-  symbol::symbol(const unistring& id)
-    : m_id(id) {}
+  symbol::symbol(const unistring& id, const struct position* position)
+    : m_id(id)
+    , m_position(position ? new struct position(*position) : nullptr) {}
+
+  symbol::~symbol()
+  {
+    if (m_position)
+    {
+      delete m_position;
+    }
+  }
 
   bool symbol::equals(const ref<value>& that) const
   {
@@ -155,7 +164,8 @@ namespace plorth
     return m_id;
   }
 
-  ref<class symbol> runtime::symbol(const unistring& id)
+  ref<class symbol> runtime::symbol(const unistring& id,
+                                    const struct position* position)
   {
 #if PLORTH_ENABLE_SYMBOL_CACHE
     const auto entry = m_symbol_cache.find(id);
@@ -171,7 +181,7 @@ namespace plorth
 
     return entry->second;
 #else
-    return new (*m_memory_manager) class symbol(id);
+    return new (*m_memory_manager) class symbol(id, position);
 #endif
   }
 

--- a/src/value-symbol.cpp
+++ b/src/value-symbol.cpp
@@ -193,6 +193,48 @@ namespace plorth
   }
 
   /**
+   * Word: position
+   * Prototype: symbol
+   *
+   * Takes:
+   * - symbol
+   *
+   * Gives:
+   * - symbol
+   * - object|null
+   *
+   * Returns position in source code where the symbols was encountered, or null
+   * if no such information is available. If symbol caching has been enabled in
+   * the interpreter, source code position is not stored in symbols.
+   *
+   * Position is returnedd as object with `filename`, `line` and `column`
+   * properties.
+   */
+  static void w_position(const ref<context>& ctx)
+  {
+    ref<value> sym;
+
+    if (ctx->pop(sym, value::type_symbol))
+    {
+      const auto position = sym.cast<symbol>()->position();
+
+      ctx->push(sym);
+      if (position)
+      {
+        const auto& runtime = ctx->runtime();
+
+        ctx->push_object({
+          { U"filename", runtime->string(position->filename) },
+          { U"line", runtime->number(number::int_type(position->line)) },
+          { U"column", runtime->number(number::int_type(position->column)) }
+        });
+      } else {
+        ctx->push_null();
+      }
+    }
+  }
+
+  /**
    * Word: call
    * Prototype: symbol
    *
@@ -220,6 +262,7 @@ namespace plorth
     {
       return
       {
+        { U"position", w_position },
         { U"call", w_call }
       };
     }


### PR DESCRIPTION
Improve error reporting and source code position tracking even more by adding source code positions into symbols and execution contexts. Every time symbol is executed, source code position of the execution context is updated with the symbol's source code position, which is used as default source code position when new exceptions are being constructed. Unfortunately, this feature remains disabled if you have symbol caching enabled.

Fixes #65