### PR TITLE
Fix infinite loop in comment parsing

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -726,6 +726,8 @@ namespace plorth
               if (peek_read('\n') || peek_read('\r'))
               {
                 break;
+              } else {
+                advance();
               }
             }
           }


### PR DESCRIPTION
If line comment does not end with line terminator, parsing such comment
will currently result in infinite loops. I really need to write parser
tests soon.