### PR TITLE
Add iterators to string and array

### DIFF
--- a/include/plorth/value-array.hpp
+++ b/include/plorth/value-array.hpp
@@ -26,6 +26,8 @@
 #ifndef PLORTH_VALUE_ARRAY_HPP_GUARD
 #define PLORTH_VALUE_ARRAY_HPP_GUARD
 
+#include <iterator>
+
 #include <plorth/value.hpp>
 
 namespace plorth
@@ -44,8 +46,14 @@ namespace plorth
     using pointer = value_type*;
     using const_pointer = const value_type*;
 
+    /**
+     * Returns the number of elements in the array.
+     */
     virtual size_type size() const = 0;
 
+    /**
+     * Returns element of the array from given index.
+     */
     virtual const_reference at(size_type offset) const = 0;
 
     inline enum type type() const
@@ -57,7 +65,58 @@ namespace plorth
     bool eval(const ref<context>& ctx, ref<value>& slot);
     unistring to_string () const;
     unistring to_source() const;
+
+    /**
+     * Iterator implementation for Plorth array.
+     */
+    class iterator
+    {
+    public:
+      using difference_type = int;
+      using value_type = const ref<value>;
+      using pointer = value_type*;
+      using reference = value_type&;
+      using iterator_category = std::forward_iterator_tag;
+
+      iterator(const ref<array>& ary, array::size_type index = 0);
+      iterator(const iterator& that);
+      iterator& operator=(const iterator& that);
+
+      iterator& operator++();
+      iterator operator++(int);
+      reference operator*();
+      reference operator->();
+
+      bool operator==(const iterator& that) const;
+      bool operator!=(const iterator& that) const;
+
+    private:
+      /** Reference to array which is being iterated. */
+      ref<array> m_array;
+      /** Current offset in the iterated array. */
+      array::size_type m_index;
+    };
+
+    inline iterator begin()
+    {
+      return iterator(this);
+    }
+
+    inline iterator end()
+    {
+      return iterator(this, size());
+    }
   };
+
+  inline array::iterator begin(const ref<array>& ary)
+  {
+    return ary->begin();
+  }
+
+  inline array::iterator end(const ref<array>& ary)
+  {
+    return ary->end();
+  }
 }
 
 #endif /* !PLORTH_VALUE_ARRAY_HPP_GUARD */

--- a/include/plorth/value-string.hpp
+++ b/include/plorth/value-string.hpp
@@ -26,6 +26,8 @@
 #ifndef PLORTH_VALUE_STRING_HPP_GUARD
 #define PLORTH_VALUE_STRING_HPP_GUARD
 
+#include <iterator>
+
 #include <plorth/value.hpp>
 
 namespace plorth
@@ -64,7 +66,57 @@ namespace plorth
     bool equals(const ref<class value>& that) const;
     unistring to_string() const;
     unistring to_source() const;
+
+    /**
+     * Iterator implementation for Plorth string.
+     */
+    class iterator
+    {
+    public:
+      using difference_type = int;
+      using value_type = unichar;
+      using pointer = value_type*;
+      using reference = value_type&;
+      using iterator_category = std::forward_iterator_tag;
+
+      iterator(const ref<string>& str, string::size_type index = 0);
+      iterator(const iterator& that);
+      iterator& operator=(const iterator& that);
+
+      iterator& operator++();
+      iterator operator++(int);
+      value_type operator*();
+
+      bool operator==(const iterator& that) const;
+      bool operator!=(const iterator& that) const;
+
+    private:
+      /** Reference to string which is being iterated. */
+      ref<string> m_string;
+      /** Current offset in the iterated string. */
+      array::size_type m_index;
+    };
+
+    inline iterator begin()
+    {
+      return iterator(this);
+    }
+
+    inline iterator end()
+    {
+      return iterator(this, length());
+    }
   };
+
+  inline string::iterator begin(const ref<string>& str)
+  {
+    return str->begin();
+  }
+
+  inline string::iterator end(const ref<string>& str)
+  {
+    return str->end();
+  }
 }
 
 #endif /* !PLORTH_VALUE_STRING_HPP_GUARD */


### PR DESCRIPTION
Make the C++ API more C++ by implementing very simple iterator classes
for both `array` and `string`, so that they can be used in range based
`for` loop.