### PR TITLE
String and array optimizations

### DIFF
--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -54,7 +54,7 @@ namespace plorth
         }
       }
 
-      size_type size() const
+      inline size_type size() const
       {
         return m_size;
       }
@@ -76,12 +76,13 @@ namespace plorth
     {
     public:
       concat_array(const ref<array>& left, const ref<array>& right)
-        : m_left(left)
+        : m_size(left->size() + right->size())
+        , m_left(left)
         , m_right(right) {}
 
-      size_type size() const
+      inline size_type size() const
       {
-        return m_left->size() + m_right->size();
+        return m_size;
       }
 
       const_reference at(size_type offset) const
@@ -97,6 +98,7 @@ namespace plorth
       }
 
     private:
+      const size_type m_size;
       const ref<array> m_left;
       const ref<array> m_right;
     };
@@ -112,7 +114,7 @@ namespace plorth
         : m_array(array)
         , m_extra(extra) {}
 
-      size_type size() const
+      inline size_type size() const
       {
         return m_array->size() + 1;
       }
@@ -145,7 +147,7 @@ namespace plorth
         , m_offset(offset)
         , m_size(size) {}
 
-      size_type size() const
+      inline size_type size() const
       {
         return m_size;
       }
@@ -170,7 +172,7 @@ namespace plorth
       explicit reversed_array(const ref<class array>& array)
         : m_array(array) {}
 
-      size_type size() const
+      inline size_type size() const
       {
         return m_array->size();
       }

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -1091,24 +1091,25 @@ namespace plorth
   {
     ref<array> ary;
     ref<number> num;
+
     if (ctx->pop_array(ary) && ctx->pop_number(num))
     {
-      const auto size = ary->size();
       const number::int_type count = num->as_int();
 
-      if (count >= 0)
+      if (count > 0)
       {
-        std::vector<ref<value>> result;
+        const auto& runtime = ctx->runtime();
+        ref<array> result = ary;
 
-        result.reserve(size * count);
-        for (number::int_type i = 0; i < count; ++i)
+        for (number::int_type i = 1; i < count; ++i)
         {
-          for (array::size_type j = 0; j < size; ++j)
-          {
-            result.push_back(ary->at(j));
-          }
+          result = runtime->value<concat_array>(result, ary);
         }
-        ctx->push_array(result.data(), size * count);
+        ctx->push(result);
+      }
+      else if (count == 0)
+      {
+        ctx->push_array(nullptr, 0);
       } else {
         ctx->error(error::code_range, U"Invalid repeat count.");
       }

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -867,27 +867,25 @@ namespace plorth
 
     if (ctx->pop_string(str) && ctx->pop_number(num))
     {
-      const auto length = str->length();
       number::int_type count = num->as_int();
-      unistring result;
 
-      if (count < 0)
+      if (count > 0)
       {
-        count = -count;
-      }
+        const auto& runtime = ctx->runtime();
+        ref<string> result = str;
 
-      result.reserve(length * count);
-
-      while (count > 0)
-      {
-        --count;
-        for (string::size_type i = 0; i < length; ++i)
+        for (number::int_type i = 1; i < count; ++i)
         {
-          result.append(1, str->at(i));
+          result = runtime->value<concat_string>(result, str);
         }
+        ctx->push(result);
       }
-
-      ctx->push_string(result);
+      else if (count == 0)
+      {
+        ctx->push_string(nullptr, 0);
+      } else {
+        ctx->error(error::code_range, U"Invalid repeat count.");
+      }
     }
   }
 

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -56,7 +56,7 @@ namespace plorth
         }
       }
 
-      size_type length() const
+      inline size_type length() const
       {
         return m_length;
       }
@@ -75,12 +75,13 @@ namespace plorth
     {
     public:
       explicit concat_string(const ref<string>& left, const ref<string>& right)
-        : m_left(left)
+        : m_length(left->length() + right->length())
+        , m_left(left)
         , m_right(right) {}
 
-      size_type length() const
+      inline size_type length() const
       {
-        return m_left->length() + m_right->length();
+        return m_length;
       }
 
       value_type at(size_type offset) const
@@ -96,6 +97,7 @@ namespace plorth
       }
 
     private:
+      const size_type m_length;
       const ref<string> m_left;
       const ref<string> m_right;
     };
@@ -110,7 +112,7 @@ namespace plorth
         , m_offset(offset)
         , m_length(length) {}
 
-      size_type length() const
+      inline size_type length() const
       {
         return m_length;
       }
@@ -135,7 +137,7 @@ namespace plorth
       explicit reversed_string(const ref<string>& original)
         : m_original(original) {}
 
-      size_type length() const
+      inline size_type length() const
       {
         return m_original->length();
       }


### PR DESCRIPTION
1. Reduce memory usage on array and string repetitions by reusing the existing array and string instances.
2. Optimize array and string concatenations by caching size of the concatenated array (or string) and making the size retrieval methods inline.