### PR TITLE
Add ability to convert arrays into quotes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -863,6 +863,19 @@ arrays and constructs a new array from values returned by the quote.
 
 ---
 
+### >quote
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>array</dd>
+  <dt>Gives:</dt>
+  <dd>quote</dd>
+</dl>
+
+Converts array into executable quote.
+
+---
+
 ### @
 
 <dl>
@@ -1973,8 +1986,8 @@ Converts the string into lower case.
   <dd>string, boolean</dd>
 </dl>
 
-Tests whether the string contains only lower case characters. Empty strings
-return false.
+Tests whether the string contains only lower case characters. Empty
+strings return false.
 
 ---
 
@@ -2014,8 +2027,8 @@ of numbers.
   <dd>string, boolean</dd>
 </dl>
 
-Tests whether the string contains only whitespace characters. Empty strings
-return false.
+Tests whether the string contains only whitespace characters. Empty
+strings return false.
 
 ---
 

--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -810,6 +810,35 @@ namespace plorth
   }
 
   /**
+   * Word: >quote
+   * Prototype: array
+   *
+   * Takes:
+   * - array
+   *
+   * Gives:
+   * - quote
+   *
+   * Converts array into executable quote.
+   */
+  static void w_to_quote(const ref<context>& ctx)
+  {
+    ref<array> ary;
+
+    if (ctx->pop_array(ary))
+    {
+      std::vector<ref<value>> elements;
+
+      elements.reserve(ary->size());
+      for (const auto& element : ary)
+      {
+        elements.push_back(element);
+      }
+      ctx->push(ctx->runtime()->compiled_quote(elements));
+    }
+  }
+
+  /**
    * Word: for-each
    * Prototype: array
    *
@@ -1360,6 +1389,7 @@ namespace plorth
         { U"uniq", w_uniq },
         { U"extract", w_extract },
         { U"join", w_join },
+        { U">quote", w_to_quote },
 
         { U"for-each", w_for_each },
         { U"2for-each", w_2for_each },

--- a/tests/test-array.plorth
+++ b/tests/test-array.plorth
@@ -126,6 +126,12 @@ test-case
 ]
 test-case
 
+">quote"
+[
+  ( [ true ] >quote call ),
+]
+test-case
+
 "+"
 [
   ( [1] [2] + [1, 2] = ),


### PR DESCRIPTION
Introduce word `>quote` to array prototype which converts array into
quote. This opens new wacky possibilities such as lazy evaluation and
emulation of variables.