### PR TITLE
Fix string and array index checking

### DIFF
--- a/src/value-array.cpp
+++ b/src/value-array.cpp
@@ -1305,7 +1305,7 @@ namespace plorth
 
       ctx->push(ary);
 
-      if (!size || index < 0 || index > static_cast<number::int_type>(size))
+      if (!size || index < 0 || index >= static_cast<number::int_type>(size))
       {
         ctx->error(error::code_range, U"Array index out of bounds.");
         return;

--- a/src/value-string.cpp
+++ b/src/value-string.cpp
@@ -925,7 +925,7 @@ namespace plorth
 
       ctx->push(str);
 
-      if (!length || index < 0 || index > static_cast<number::int_type>(length))
+      if (!length || index < 0 || index >= static_cast<number::int_type>(length))
       {
         ctx->error(error::code_range, U"String index out of bounds.");
         return;


### PR DESCRIPTION
Index checking for strings and arrays is currently flawed, as it allows
length plus one access.