### PR TITLE
Fix print operator with smart pointers

### DIFF
--- a/libplorth/include/plorth/value.hpp
+++ b/libplorth/include/plorth/value.hpp
@@ -151,7 +151,7 @@ namespace plorth
   bool operator!=(const std::shared_ptr<value>&, const std::shared_ptr<value>&);
 
   std::ostream& operator<<(std::ostream&, enum value::type);
-  std::ostream& operator<<(std::ostream&, const std::shared_ptr<value>&);
+  std::ostream& operator<<(std::ostream&, const value*);
 }
 
 #endif /* !PLORTH_VALUE_HPP_GUARD */

--- a/libplorth/src/value.cpp
+++ b/libplorth/src/value.cpp
@@ -142,8 +142,7 @@ namespace plorth
     return out;
   }
 
-  std::ostream& operator<<(std::ostream& os,
-                           const std::shared_ptr<class value>& value)
+  std::ostream& operator<<(std::ostream& os, const class value* value)
   {
     if (value)
     {


### PR DESCRIPTION
Printing plorth values into C++ streams is currently broken because of
the switch to smart pointers. Providing `<<` operator that works
directly on pointers fixes the issue.