### PR TITLE
Fix paths in Doxyfile

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -790,8 +790,8 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./src \
-                         ./include/plorth
+INPUT                  = ./libplorth/src \
+                         ./libplorth/include/plorth
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -874,7 +874,8 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                = ./libplorth/src/utils.hpp \
+                         ./libplorth/src/utils.cpp
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
Paths in `Doxyfile` still point to old locations, which have been since
changed. Update `Doxyfile` to fix this.