### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Features:
 
 ## Compilation
 
-Plorth has no dependencies. Only C++11 capable compiler and [CMake] are required to
-compile Plorth interpreter.
+Plorth has no dependencies. Only C++11 capable compiler and [CMake] are
+required to compile Plorth interpreter.
 
 ```bash
 mkdir build
@@ -26,7 +26,7 @@ cmake ..
 make
 ```
 
-After the interpreter has been successfully compiled, you can run the `plorth-cli`
+After the interpreter has been successfully compiled, you can run the `plorth`
 binary to start Plorth REPL.
 
 [Forth]: https://www.forth.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+plorth.org

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,15 +30,15 @@ $ make
 
 This will begin compilation of the interpreter. The interpreter consists of
 two parts: Plorth interpreter library and it's command line user interface
-known as `plorth-cli` which uses the interpreter library. By tweaking the CMake
-options, it's also possible to compile only the library without `plorth-cli`
+known as `plorth` which uses the interpreter library. By tweaking the CMake
+options, it's also possible to compile only the library without `plorth`
 executable, if you plan to embed the interpreter to your own C++ application.
 
 ## Installation
 
-After the interpreter has been compiled, you can run the `plorth-cli` executable
-located in `build` directory. Alternatively, you can also install Plorth into
-your system by running the following command:
+After the interpreter has been compiled, you can run the `plorth` executable
+located in `build/plorth` directory. Alternatively, you can also install Plorth
+into your system by running the following command:
 
 ```bash
 sudo make install


### PR DESCRIPTION
Update CLI interpreter binary name and move `CNAME` file from `gh-pages` branch into `docs` directory.