### PR TITLE
Add words for reading from standard input

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -440,6 +440,23 @@ Returns the number of seconds that have elapsed since the  Unix epoch
 
 ---
 
+### nread
+
+<dl>
+  <dt>Takes:</dt>
+  <dd>number</dd>
+  <dt>Gives:</dt>
+  <dd>string|null</dd>
+</dl>
+
+Reads given number of Unicode characters from standard input stream and
+returns them in a string. If there is no more input to be read, null will
+be returned instead. The resulting string might have less than given
+number of characters if there isn't that much characters available from
+the standard input stream.
+
+---
+
 ### null
 
 <dl>
@@ -579,6 +596,19 @@ Returns true if the topmost value of the stack is a quote.
 
 Construct an instance of range error with given optional error message
 and places it on the stack.
+
+---
+
+### read
+
+<dl>
+  <dt>Gives:</dt>
+  <dd>string|null</dd>
+</dl>
+
+Reads all available input from standard input stream, decodes it as UTF-8
+encoded text and returns result. If end of input has been reached, null
+will be returned instead.
 
 ---
 

--- a/libplorth/include/plorth/runtime.hpp
+++ b/libplorth/include/plorth/runtime.hpp
@@ -38,6 +38,19 @@
 
 namespace plorth
 {
+  /**
+   * Represents results of read operation.
+   */
+  enum read_result
+  {
+    /** Reading from standard input stream was successful. */
+    read_result_ok,
+    /** End of input was encountered. */
+    read_result_eof,
+    /** UTF-8 decoding error was encountered. */
+    read_result_failure
+  };
+
   class runtime : public memory::managed
   {
   public:
@@ -136,6 +149,12 @@ namespace plorth
     {
       return m_imported_modules;
     }
+
+    /**
+     * Reads Unicode code points from standard input stream and places them in
+     * the string given as argument.
+     */
+    read_result read(unistring& output, std::size_t size, std::size_t& read);
 
     /**
      * Outputs given Unicode string into the standard output stream of the

--- a/libplorth/include/plorth/unicode.hpp
+++ b/libplorth/include/plorth/unicode.hpp
@@ -124,6 +124,14 @@ namespace plorth
    * Converts given Unicode character into lower case.
    */
   unichar unichar_tolower(unichar);
+
+  /**
+   * Attempts to determine length (in bytes) of UTF-8 sequence which begins
+   * with the given byte. If the length cannot be determined (i.e. beginning of
+   * sequence is invalid according to UTF-8 specification), 0 will be returned
+   * instead.
+   */
+  std::size_t utf8_sequence_length(unsigned char);
 }
 
 #endif /* !PLORTH_UNICODE_HPP_GUARD */

--- a/libplorth/include/plorth/value-error.hpp
+++ b/libplorth/include/plorth/value-error.hpp
@@ -48,6 +48,8 @@ namespace plorth
       code_range = 5,
       /** Import error. */
       code_import = 6,
+      /** I/O error. */
+      code_io = 7,
       /** Unknown error. */
       code_unknown = 100
     };

--- a/libplorth/src/runtime.cpp
+++ b/libplorth/src/runtime.cpp
@@ -119,6 +119,52 @@ namespace plorth
     );
   }
 
+  read_result runtime::read(unistring& output,
+                            std::size_t size,
+                            std::size_t& read)
+  {
+    const bool infinite = !size;
+    const auto eof = std::char_traits<char>::eof();
+    std::string buffer;
+
+    buffer.reserve(6);
+    while (infinite || size > 0)
+    {
+      auto c = std::cin.get();
+      std::size_t unichar_size;
+
+      if (c == eof)
+      {
+        return read_result_eof;
+      }
+      else if (!(unichar_size = utf8_sequence_length(c)))
+      {
+        return read_result_failure;
+      }
+      buffer.clear();
+      buffer.append(1, c);
+      for (std::size_t i = 1; i < unichar_size; ++i)
+      {
+        if ((c = std::cin.get()) == eof)
+        {
+          return read_result_failure;
+        }
+        buffer.append(1, c);
+      }
+      if (!utf8_decode_test(buffer, output))
+      {
+        return read_result_failure;
+      }
+      if (!infinite)
+      {
+        --size;
+      }
+      ++read;
+    }
+
+    return read_result_ok;
+  }
+
   void runtime::print(const unistring& str) const
   {
     std::cout << str;

--- a/libplorth/src/unicode.cpp
+++ b/libplorth/src/unicode.cpp
@@ -27,7 +27,6 @@
 
 namespace plorth
 {
-  static inline std::size_t utf8_sequence_length(unsigned char);
   static bool utf8_advance(std::string::const_iterator&,
                            const std::string::const_iterator&,
                            unichar&);
@@ -273,7 +272,7 @@ namespace plorth
     return true;
   }
 
-  static inline std::size_t utf8_sequence_length(unsigned char input)
+  std::size_t utf8_sequence_length(unsigned char input)
   {
     if ((input & 0x80) == 0x00)
     {

--- a/libplorth/src/value-error.cpp
+++ b/libplorth/src/value-error.cpp
@@ -69,6 +69,9 @@ namespace plorth
     case error::code_import:
       return U"Import error";
 
+    case error::code_io:
+      return U"I/O error";
+
     case error::code_unknown:
       return U"Unknown error";
     }

--- a/scripts/generator-apidoc.pl
+++ b/scripts/generator-apidoc.pl
@@ -42,7 +42,7 @@ use utf8;
 
 my %prototypes;
 
-for my $file (glob("./libplorth/*.cpp"))
+for my $file (glob("./libplorth/src/*.cpp"))
 {
   my $in_doc_comment = 0;
   my $in_takes_list = 0;


### PR DESCRIPTION
Introduce two new words; `read` and `nread` which can be used to read text encoded in UTF-8 from standard input.