### PR TITLE
Add dictionary container class

### DIFF
--- a/libplorth/CMakeLists.txt
+++ b/libplorth/CMakeLists.txt
@@ -76,6 +76,7 @@ ADD_LIBRARY(
   SHARED
   src/compiler.cpp
   src/context.cpp
+  src/dictionary.cpp
   src/exec.cpp
   src/eval.cpp
   src/globals.cpp

--- a/libplorth/include/plorth/context.hpp
+++ b/libplorth/include/plorth/context.hpp
@@ -42,8 +42,6 @@ namespace plorth
   {
   public:
     using container_type = std::deque<std::shared_ptr<value>>;
-    using dictionary_type = std::unordered_map<std::shared_ptr<symbol>,
-                                               std::shared_ptr<quote>>;
 
     /**
      * Constructs new context.
@@ -103,7 +101,7 @@ namespace plorth
     /**
      * Returns the dictionary used by this context to store words.
      */
-    inline dictionary_type& dictionary()
+    inline class dictionary& dictionary()
     {
       return m_dictionary;
     }
@@ -111,7 +109,7 @@ namespace plorth
     /**
      * Returns the dictionary used by this context to store words.
      */
-    inline const dictionary_type& dictionary() const
+    inline const class dictionary& dictionary() const
     {
       return m_dictionary;
     }
@@ -436,7 +434,7 @@ namespace plorth
     /** Data stack used for storing values in this context. */
     container_type m_data;
     /** Container for words associated with this context. */
-    dictionary_type m_dictionary;
+    class dictionary m_dictionary;
 #if PLORTH_ENABLE_MODULES
     /** Optional filename of the context, when executed as module. */
     unistring m_filename;

--- a/libplorth/include/plorth/dictionary.hpp
+++ b/libplorth/include/plorth/dictionary.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017-2018, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PLORTH_DICTIONARY_HPP
+#define PLORTH_DICTIONARY_HPP
+
+#include <plorth/value-word.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+namespace plorth
+{
+  /**
+   * Dictionary is a collection of words, containing one quote for each
+   * individual symbol.
+   */
+  class dictionary
+  {
+  public:
+    using value_type = std::shared_ptr<word>;
+    /** Underlying container type. */
+    using container_type = std::unordered_map<unistring, value_type>;
+
+    /**
+     * Constructs new empty dictionary.
+     */
+    dictionary();
+
+    /**
+     * Constructs copy of existing dictionary.
+     */
+    dictionary(const dictionary& that);
+
+    /**
+     * Copies contents of another dictionary into this one.
+     */
+    dictionary& operator=(const dictionary& that);
+
+    /**
+     * Returns words from the dictionary as iterable vector.
+     */
+    std::vector<value_type> words() const;
+
+    /**
+     * Searches for a word from the dictionary which symbol matches with given
+     * symbol. If no such word is found from the dictionary, null reference
+     * will be returned instead.
+     */
+    value_type find(const std::shared_ptr<symbol>& id) const;
+
+    /**
+     * Searches for a word from the dictionary which symbol matches with given
+     * string. If no such word is found from the dictionary, null reference
+     * will be returned instead.
+     */
+    value_type find(const unistring& id) const;
+
+    /**
+     * Inserts given word into the dictionary. Existing words with identical
+     * symbol will be overridden.
+     */
+    void insert(const value_type& word);
+
+  private:
+    /** Container for the words in the dictionary. */
+    container_type m_words;
+  };
+}
+
+#endif /* !PLORTH_DICTIONARY_HPP */

--- a/libplorth/include/plorth/runtime.hpp
+++ b/libplorth/include/plorth/runtime.hpp
@@ -26,15 +26,12 @@
 #ifndef PLORTH_RUNTIME_HPP_GUARD
 #define PLORTH_RUNTIME_HPP_GUARD
 
+#include <plorth/dictionary.hpp>
 #include <plorth/value-array.hpp>
 #include <plorth/value-boolean.hpp>
 #include <plorth/value-number.hpp>
 #include <plorth/value-object.hpp>
-#include <plorth/value-quote.hpp>
 #include <plorth/value-string.hpp>
-#include <plorth/value-symbol.hpp>
-
-#include <vector>
 
 namespace plorth
 {
@@ -56,8 +53,6 @@ namespace plorth
   public:
     using prototype_definition = std::vector<std::pair<const char32_t*,
                                                        quote::callback>>;
-    using dictionary_type = std::unordered_map<std::shared_ptr<class symbol>,
-                                               std::shared_ptr<quote>>;
 #if PLORTH_ENABLE_SYMBOL_CACHE
     using symbol_cache = std::unordered_map<unistring,
                                            std::shared_ptr<class symbol>>;
@@ -86,7 +81,7 @@ namespace plorth
      * This non-constant version of the method can be used to define new words
      * into the global dictionary, or remove existing ones.
      */
-    inline dictionary_type& dictionary()
+    inline class dictionary& dictionary()
     {
       return m_dictionary;
     }
@@ -95,7 +90,7 @@ namespace plorth
      * Returns the global dictionary that contains core word set available to
      * all contexts.
      */
-    inline const dictionary_type& dictionary() const
+    inline const class dictionary& dictionary() const
     {
       return m_dictionary;
     }
@@ -253,6 +248,22 @@ namespace plorth
     std::shared_ptr<quote> native_quote(quote::callback callback);
 
     /**
+     * Constructs word from given string and quote.
+     */
+    std::shared_ptr<class word> word(
+      const unistring& id,
+      const std::shared_ptr<class quote>& quote
+    );
+
+    /**
+     * Constructs word from given symbol and quote.
+     */
+    std::shared_ptr<class word> word(
+      const std::shared_ptr<class symbol>& symbol,
+      const std::shared_ptr<class quote>& quote
+    );
+
+    /**
      * Helper method for constructing managed objects (such as values) using
      * the memory manager associated with this runtime instance.
      */
@@ -363,7 +374,7 @@ namespace plorth
     /** Memory manager associated with this runtime. */
     memory::manager* m_memory_manager;
     /** Global dictionary available to all contexts. */
-    dictionary_type m_dictionary;
+    class dictionary m_dictionary;
     /** Shared instance of true boolean value. */
     std::shared_ptr<class boolean> m_true_value;
     /** Shared instance of false boolean value. */

--- a/libplorth/src/compiler.cpp
+++ b/libplorth/src/compiler.cpp
@@ -24,7 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <plorth/context.hpp>
-#include <plorth/value-word.hpp>
 
 namespace plorth
 {
@@ -302,10 +301,7 @@ namespace plorth
           }
         }
 
-        return runtime->value<word>(
-          symbol,
-          runtime->compiled_quote(values)
-        );
+        return runtime->word(symbol, runtime->compiled_quote(values));
       }
 
       std::shared_ptr<quote> compile_quote(context* ctx)

--- a/libplorth/src/context.cpp
+++ b/libplorth/src/context.cpp
@@ -102,7 +102,7 @@ namespace plorth
   void context::push_word(const std::shared_ptr<class symbol>& symbol,
                           const std::shared_ptr<class quote>& quote)
   {
-    push(m_runtime->value<word>(symbol, quote));
+    push(m_runtime->word(symbol, quote));
   }
 
   bool context::pop()

--- a/libplorth/src/dictionary.cpp
+++ b/libplorth/src/dictionary.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017-2018, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <plorth/dictionary.hpp>
+
+namespace plorth
+{
+  dictionary::dictionary() {}
+
+  dictionary::dictionary(const dictionary& that)
+    : m_words(that.m_words) {}
+
+  dictionary& dictionary::operator=(const dictionary& that)
+  {
+    m_words = that.m_words;
+
+    return *this;
+  }
+
+  dictionary::value_type dictionary::find(
+    const std::shared_ptr<symbol>& id
+  ) const
+  {
+    return find(id->id());
+  }
+
+  std::vector<dictionary::value_type> dictionary::words() const
+  {
+    std::vector<value_type> result;
+
+    result.reserve(m_words.size());
+    for (const auto& entry : m_words)
+    {
+      result.push_back(entry.second);
+    }
+
+    return result;
+  }
+
+  dictionary::value_type dictionary::find(const unistring& id) const
+  {
+    const auto entry = m_words.find(id);
+
+    if (entry == std::end(m_words))
+    {
+      return value_type();
+    } else {
+      return entry->second;
+    }
+  }
+
+  void dictionary::insert(const value_type& word)
+  {
+    m_words[word->symbol()->id()] = word;
+  }
+}

--- a/libplorth/src/exec.cpp
+++ b/libplorth/src/exec.cpp
@@ -108,14 +108,9 @@ namespace plorth
     }
 
     // Look for a word from dictionary of current context.
+    if (auto word = ctx->dictionary().find(sym))
     {
-      const auto& local_dictionary = ctx->dictionary();
-      const auto entry = local_dictionary.find(sym);
-
-      if (entry != std::end(local_dictionary) && entry->second)
-      {
-        return entry->second->call(ctx);
-      }
+      return word->quote()->call(ctx);
     }
 
     // TODO: If not found, see if it's a "fully qualified" name, e.g. a name
@@ -123,14 +118,9 @@ namespace plorth
     // for that from the specified namespace.
 
     // Look from global dictionary.
+    if (auto word = ctx->runtime()->dictionary().find(sym))
     {
-      const auto& global_dictionary = ctx->runtime()->dictionary();
-      const auto entry = global_dictionary.find(sym);
-
-      if (entry != std::end(global_dictionary) && entry->second)
-      {
-        return entry->second->call(ctx);
-      }
+      return word->quote()->call(ctx);
     }
 
     // If the name of the word can be converted into number, then do just that.
@@ -150,7 +140,7 @@ namespace plorth
   static bool exec_wrd(const std::shared_ptr<context>& ctx,
                        const std::shared_ptr<word>& wrd)
   {
-    ctx->dictionary()[wrd->symbol()] = wrd->quote();
+    ctx->dictionary().insert(wrd);
 
     return true;
   }

--- a/libplorth/src/globals.cpp
+++ b/libplorth/src/globals.cpp
@@ -1104,9 +1104,9 @@ namespace plorth
   {
     object::container_type result;
 
-    for (const auto& entry : ctx->runtime()->dictionary())
+    for (const auto& word : ctx->runtime()->dictionary().words())
     {
-      result[entry.first->id()] = entry.second;
+      result[word->symbol()->id()] = word->quote();
     }
     ctx->push_object(result);
   }
@@ -1123,9 +1123,9 @@ namespace plorth
   {
     object::container_type result;
 
-    for (const auto& entry : ctx->dictionary())
+    for (const auto& word : ctx->dictionary().words())
     {
-      result[entry.first->id()] = entry.second;
+      result[word->symbol()->id()] = word->quote();
     }
     ctx->push_object(result);
   }
@@ -1149,7 +1149,10 @@ namespace plorth
     {
       const auto& runtime = ctx->runtime();
 
-      ctx->dictionary()[runtime->symbol(id->to_string())] = runtime->compiled_quote({ val });
+      ctx->dictionary().insert(runtime->word(
+        runtime->symbol(id->to_string()),
+        runtime->compiled_quote({ val })
+      ));
     }
   }
 

--- a/libplorth/src/module.cpp
+++ b/libplorth/src/module.cpp
@@ -79,8 +79,10 @@ namespace plorth
     {
       if (property.second && property.second->is(value::type_quote))
       {
-        m_dictionary[m_runtime->symbol(property.first)]
-          = std::static_pointer_cast<quote>(property.second);
+        m_dictionary.insert(m_runtime->word(
+          m_runtime->symbol(property.first),
+          std::static_pointer_cast<quote>(property.second)
+        ));
       }
     }
 
@@ -149,9 +151,9 @@ namespace plorth
     }
 
     // Finally convert the module into object.
-    for (const auto& entry : module_ctx->dictionary())
+    for (const auto& word : module_ctx->dictionary().words())
     {
-      result[entry.first->id()] = entry.second;
+      result[word->symbol()->id()] = word->quote();
     }
 
     return ctx->runtime()->value<object>(result);

--- a/libplorth/src/runtime.cpp
+++ b/libplorth/src/runtime.cpp
@@ -60,7 +60,10 @@ namespace plorth
 
     for (auto& entry : api::global_dictionary())
     {
-      m_dictionary[symbol(entry.first)] = native_quote(entry.second);
+      m_dictionary.insert(word(
+        symbol(entry.first),
+        native_quote(entry.second)
+      ));
     }
 
     m_object_prototype = make_prototype(
@@ -206,12 +209,15 @@ namespace plorth
     // given.
     if (name)
     {
-      runtime->dictionary()[runtime->symbol(name)] = runtime->compiled_quote({
-        runtime->value<object>(object::container_type({
-          { U"__proto__", runtime->object_prototype() },
-          { U"prototype", prototype }
-        }))
-      });
+      runtime->dictionary().insert(runtime->word(
+        runtime->symbol(name),
+        runtime->compiled_quote({
+          runtime->value<object>(object::container_type({
+            { U"__proto__", runtime->object_prototype() },
+            { U"prototype", prototype }
+          }))
+        })
+      ));
     }
 
     return prototype;

--- a/libplorth/src/value-word.cpp
+++ b/libplorth/src/value-word.cpp
@@ -56,6 +56,22 @@ namespace plorth
     return U": " + m_symbol->id() + U" " + m_quote->to_string() + U" ;";
   }
 
+  std::shared_ptr<word> runtime::word(
+    const unistring& id,
+    const std::shared_ptr<class quote>& quote
+  )
+  {
+    return word(symbol(id), quote);
+  }
+
+  std::shared_ptr<word> runtime::word(
+    const std::shared_ptr<class symbol>& symbol,
+    const std::shared_ptr<class quote>& quote
+  )
+  {
+    return value<class word>(symbol, quote);
+  }
+
   /**
    * Word: symbol
    * Prototype: word

--- a/plorth/src/repl.cpp
+++ b/plorth/src/repl.cpp
@@ -45,6 +45,12 @@ void initialize_repl_api(const std::shared_ptr<runtime>& runtime)
 {
   auto& dictionary = runtime->dictionary();
 
-  dictionary[runtime->symbol(U".q")] = runtime->native_quote(w_quit);
-  dictionary[runtime->symbol(U".s")] = runtime->native_quote(w_stack);
+  dictionary.insert(runtime->word(
+    runtime->symbol(U".q"),
+    runtime->native_quote(w_quit)
+  ));
+  dictionary.insert(runtime->word(
+    runtime->symbol(U".s"),
+    runtime->native_quote(w_stack)
+  ));
 }


### PR DESCRIPTION
Unify dictionaries between execution contexes and runtime by introducing
dictionary container class which can be used to store words.