### PR TITLE
Use factory methods instead of constructors

### DIFF
--- a/libplorth/include/plorth/context.hpp
+++ b/libplorth/include/plorth/context.hpp
@@ -47,8 +47,11 @@ namespace plorth
      * Constructs new context.
      *
      * \param runtime Runtime associated with this context.
+     * \return        Reference to the created context.
      */
-    explicit context(const std::shared_ptr<class runtime>& runtime);
+    static std::shared_ptr<context> make(
+      const std::shared_ptr<class runtime>& runtime
+    );
 
     /**
      * Returns the runtime associated with this context.
@@ -425,6 +428,14 @@ namespace plorth
     {
       return m_position;
     }
+
+  protected:
+    /**
+     * Constructs new context.
+     *
+     * \param runtime Runtime associated with this context.
+     */
+    explicit context(const std::shared_ptr<class runtime>& runtime);
 
   private:
     /** Runtime associated with this context. */

--- a/libplorth/include/plorth/memory.hpp
+++ b/libplorth/include/plorth/memory.hpp
@@ -70,20 +70,6 @@ namespace plorth
        */
       void* allocate(std::size_t size);
 
-      /**
-       * Creates new scripting runtime that uses this memory manager for memory
-       * allocation.
-       */
-      std::shared_ptr<runtime> new_runtime();
-
-      /**
-       * Creates new scripting context that uses given scripting runtime as
-       * it's runtime.
-       */
-      std::shared_ptr<context> new_context(
-        const std::shared_ptr<class runtime>& runtime
-      );
-
       manager(const manager&) = delete;
       manager(manager&&) = delete;
       void operator=(const manager&) = delete;

--- a/libplorth/include/plorth/runtime.hpp
+++ b/libplorth/include/plorth/runtime.hpp
@@ -51,20 +51,23 @@ namespace plorth
   class runtime : public memory::managed
   {
   public:
-    using prototype_definition = std::vector<std::pair<const char32_t*,
-                                                       quote::callback>>;
+    using prototype_definition = std::vector<
+      std::pair<const char32_t*, quote::callback>
+    >;
 #if PLORTH_ENABLE_SYMBOL_CACHE
-    using symbol_cache = std::unordered_map<unistring,
-                                           std::shared_ptr<class symbol>>;
+    using symbol_cache = std::unordered_map<
+      unistring,
+      std::shared_ptr<class symbol>
+    >;
 #endif
 
     /**
      * Constructs new runtime.
      *
-     * \param memory_manager Pointer to the memory manager to use for
-     *                       allocating memory.
+     * \param memory_manager Memory manager to use for allocating memory.
+     * \return               Reference to the created runtime.
      */
-    explicit runtime(memory::manager* memory_manager);
+    static std::shared_ptr<runtime> make(memory::manager& memory_manager);
 
     /**
      * Returns the memory manager used by this scripting runtime.
@@ -369,6 +372,15 @@ namespace plorth
     {
       return m_word_prototype;
     }
+
+  protected:
+    /**
+     * Constructs new runtime.
+     *
+     * \param memory_manager Pointer to the memory manager to use for
+     *                       allocating memory.
+     */
+    explicit runtime(memory::manager* memory_manager);
 
   private:
     /** Memory manager associated with this runtime. */

--- a/libplorth/src/context.cpp
+++ b/libplorth/src/context.cpp
@@ -30,6 +30,15 @@
 
 namespace plorth
 {
+  std::shared_ptr<context> context::make(
+    const std::shared_ptr<class runtime>& runtime
+  )
+  {
+    return std::shared_ptr<context>(new (runtime->memory_manager()) context(
+      runtime
+    ));
+  }
+
   context::context(const std::shared_ptr<class runtime>& runtime)
     : m_runtime(runtime) {}
 

--- a/libplorth/src/memory.cpp
+++ b/libplorth/src/memory.cpp
@@ -120,16 +120,6 @@ namespace plorth
 #endif
     }
 
-    std::shared_ptr<runtime> manager::new_runtime()
-    {
-      return std::shared_ptr<runtime>(new (*this) runtime(this));
-    }
-
-    std::shared_ptr<context> manager::new_context(const std::shared_ptr<class runtime>& runtime)
-    {
-      return std::shared_ptr<context>(new (*this) context(runtime));
-    }
-
     managed::managed() {}
 
     managed::~managed() {}

--- a/libplorth/src/module.cpp
+++ b/libplorth/src/module.cpp
@@ -136,7 +136,7 @@ namespace plorth
     }
 
     // Run the module code inside new execution context.
-    module_ctx = ctx->runtime()->memory_manager().new_context(ctx->runtime());
+    module_ctx = context::make(ctx->runtime());
     module_ctx->filename(path);
     if (!compiled_module->call(module_ctx))
     {

--- a/libplorth/src/runtime.cpp
+++ b/libplorth/src/runtime.cpp
@@ -45,10 +45,19 @@ namespace plorth
     runtime::prototype_definition word_prototype();
   }
 
-  static inline std::shared_ptr<object> make_prototype(runtime*,
-                                                       const char32_t*,
-                                                       const std::shared_ptr<object>&,
-                                                       const runtime::prototype_definition&);
+  static inline std::shared_ptr<object> make_prototype(
+    runtime*,
+    const char32_t*,
+    const std::shared_ptr<object>&,
+    const runtime::prototype_definition&
+  );
+
+  std::shared_ptr<runtime> runtime::make(memory::manager& memory_manager)
+  {
+    return std::shared_ptr<runtime>(new (memory_manager) runtime(
+      &memory_manager
+    ));
+  }
 
   runtime::runtime(memory::manager* memory_manager)
     : m_memory_manager(memory_manager)
@@ -190,10 +199,12 @@ namespace plorth
     println();
   }
 
-  static inline std::shared_ptr<object> make_prototype(class runtime* runtime,
-                                                       const char32_t* name,
-                                                       const std::shared_ptr<object>& parent_prototype,
-                                                       const runtime::prototype_definition& definition)
+  static inline std::shared_ptr<object> make_prototype(
+    class runtime* runtime,
+    const char32_t* name,
+    const std::shared_ptr<object>& parent_prototype,
+    const runtime::prototype_definition& definition
+  )
   {
     object::container_type properties;
     std::shared_ptr<object> prototype;

--- a/plorth-webassembly/src/main.cpp
+++ b/plorth-webassembly/src/main.cpp
@@ -123,7 +123,7 @@ static void plorth_initialize()
     return;
   }
   memory_manager = new memory::manager();
-  plorth_runtime = memory_manager->new_runtime();
-  plorth_context = memory_manager->new_context(plorth_runtime);
+  plorth_runtime = runtime::make(*memory_manager);
+  plorth_context = context::make(plorth_runtime);
   initialize_repl_api(plorth_runtime);
 }

--- a/plorth/src/main.cpp
+++ b/plorth/src/main.cpp
@@ -61,8 +61,8 @@ void initialize_repl_api(const std::shared_ptr<runtime>&);
 int main(int argc, char** argv)
 {
   memory::manager memory_manager;
-  std::shared_ptr<runtime> runtime = memory_manager.new_runtime();
-  std::shared_ptr<context> context = memory_manager.new_context(runtime);
+  auto runtime = runtime::make(memory_manager);
+  auto context = context::make(runtime);
 
 #if PLORTH_ENABLE_MODULES
   scan_module_path(runtime);


### PR DESCRIPTION
Do not expose the constructors of `runtime` and `context` classes, but
instead introduce factory methods for constructing them. For shit and
giggles mostly, I just think that this API is more neater as you don't
have to directly deal with pointers to the memory manager or anything.