### PR TITLE
Move iterator classes inside the container classes

### DIFF
--- a/libplorth/include/plorth/value-array.hpp
+++ b/libplorth/include/plorth/value-array.hpp
@@ -45,6 +45,7 @@ namespace plorth
     using const_reference = const value_type&;
     using pointer = value_type*;
     using const_pointer = const value_type*;
+    class iterator;
 
     /**
      * Returns the number of elements in the array.
@@ -69,7 +70,7 @@ namespace plorth
   /**
    * Iterator implementation for Plorth array.
    */
-  class array_iterator
+  class array::iterator
   {
   public:
     using difference_type = int;
@@ -78,18 +79,17 @@ namespace plorth
     using reference = value_type&;
     using iterator_category = std::forward_iterator_tag;
 
-    array_iterator(const std::shared_ptr<array>& ary,
-                   array::size_type index = 0);
-    array_iterator(const array_iterator& that);
-    array_iterator& operator=(const array_iterator& that);
+    iterator(const std::shared_ptr<array>& ary, array::size_type index = 0);
+    iterator(const iterator& that);
+    iterator& operator=(const iterator& that);
 
-    array_iterator& operator++();
-    array_iterator operator++(int);
+    iterator& operator++();
+    iterator operator++(int);
     reference operator*();
     reference operator->();
 
-    bool operator==(const array_iterator& that) const;
-    bool operator!=(const array_iterator& that) const;
+    bool operator==(const iterator& that) const;
+    bool operator!=(const iterator& that) const;
 
   private:
     /** Reference to array which is being iterated. */
@@ -98,14 +98,14 @@ namespace plorth
     array::size_type m_index;
   };
 
-  inline array_iterator begin(const std::shared_ptr<array>& ary)
+  inline array::iterator begin(const std::shared_ptr<array>& ary)
   {
-    return array_iterator(ary);
+    return array::iterator(ary);
   }
 
-  inline array_iterator end(const std::shared_ptr<array>& ary)
+  inline array::iterator end(const std::shared_ptr<array>& ary)
   {
-    return array_iterator(ary, ary->size());
+    return array::iterator(ary, ary->size());
   }
 }
 

--- a/libplorth/include/plorth/value-string.hpp
+++ b/libplorth/include/plorth/value-string.hpp
@@ -39,6 +39,7 @@ namespace plorth
     using value_type = unichar;
     using pointer = value_type*;
     using const_pointer = const value_type*;
+    class iterator;
 
     /**
      * Tests whether the string is empty.
@@ -71,7 +72,7 @@ namespace plorth
   /**
    * Iterator implementation for Plorth string.
    */
-  class string_iterator
+  class string::iterator
   {
   public:
     using difference_type = int;
@@ -80,17 +81,16 @@ namespace plorth
     using reference = value_type&;
     using iterator_category = std::forward_iterator_tag;
 
-    string_iterator(const std::shared_ptr<string>& str,
-                    string::size_type index = 0);
-    string_iterator(const string_iterator& that);
-    string_iterator& operator=(const string_iterator& that);
+    iterator(const std::shared_ptr<string>& str, string::size_type index = 0);
+    iterator(const iterator& that);
+    iterator& operator=(const iterator& that);
 
-    string_iterator& operator++();
-    string_iterator operator++(int);
+    iterator& operator++();
+    iterator operator++(int);
     value_type operator*();
 
-    bool operator==(const string_iterator& that) const;
-    bool operator!=(const string_iterator& that) const;
+    bool operator==(const iterator& that) const;
+    bool operator!=(const iterator& that) const;
 
   private:
     /** Reference to string which is being iterated. */
@@ -99,14 +99,14 @@ namespace plorth
     array::size_type m_index;
   };
 
-  inline string_iterator begin(const std::shared_ptr<string>& str)
+  inline string::iterator begin(const std::shared_ptr<string>& str)
   {
-    return string_iterator(str);
+    return string::iterator(str);
   }
 
-  inline string_iterator end(const std::shared_ptr<string>& str)
+  inline string::iterator end(const std::shared_ptr<string>& str)
   {
-    return string_iterator(str, str->length());
+    return string::iterator(str, str->length());
   }
 }
 

--- a/libplorth/src/value-array.cpp
+++ b/libplorth/src/value-array.cpp
@@ -266,16 +266,16 @@ namespace plorth
     return result;
   }
 
-  array_iterator::array_iterator(const std::shared_ptr<array>& ary,
-                                 array::size_type index)
+  array::iterator::iterator(const std::shared_ptr<array>& ary,
+                            array::size_type index)
     : m_array(ary)
     , m_index(index) {}
 
-  array_iterator::array_iterator(const array_iterator& that)
+  array::iterator::iterator(const iterator& that)
     : m_array(that.m_array)
     , m_index(that.m_index) {}
 
-  array_iterator& array_iterator::operator=(const array_iterator& that)
+  array::iterator& array::iterator::operator=(const iterator& that)
   {
     m_array = that.m_array;
     m_index = that.m_index;
@@ -283,38 +283,38 @@ namespace plorth
     return *this;
   }
 
-  array_iterator& array_iterator::operator++()
+  array::iterator& array::iterator::operator++()
   {
     ++m_index;
 
     return *this;
   }
 
-  array_iterator array_iterator::operator++(int)
+  array::iterator array::iterator::operator++(int)
   {
-    array_iterator copy(*this);
+    const iterator copy(*this);
 
     ++m_index;
 
     return copy;
   }
 
-  array_iterator::reference array_iterator::operator*()
+  array::iterator::reference array::iterator::operator*()
   {
     return m_array->at(m_index);
   }
 
-  array_iterator::reference array_iterator::operator->()
+  array::iterator::reference array::iterator::operator->()
   {
     return m_array->at(m_index);
   }
 
-  bool array_iterator::operator==(const array_iterator& that) const
+  bool array::iterator::operator==(const iterator& that) const
   {
     return m_index == that.m_index;
   }
 
-  bool array_iterator::operator!=(const array_iterator& that) const
+  bool array::iterator::operator!=(const iterator& that) const
   {
     return m_index != that.m_index;
   }

--- a/libplorth/src/value-string.cpp
+++ b/libplorth/src/value-string.cpp
@@ -197,16 +197,16 @@ namespace plorth
     return json_stringify(to_string());
   }
 
-  string_iterator::string_iterator(const std::shared_ptr<string>& str,
-                                   string::size_type index)
+  string::iterator::iterator(const std::shared_ptr<string>& str,
+                             string::size_type index)
     : m_string(str)
     , m_index(index) {}
 
-  string_iterator::string_iterator(const string_iterator& that)
+  string::iterator::iterator(const iterator& that)
     : m_string(that.m_string)
     , m_index(that.m_index) {}
 
-  string_iterator& string_iterator::operator=(const string_iterator& that)
+  string::iterator& string::iterator::operator=(const iterator& that)
   {
     m_string = that.m_string;
     m_index = that.m_index;
@@ -214,33 +214,33 @@ namespace plorth
     return *this;
   }
 
-  string_iterator& string_iterator::operator++()
+  string::iterator& string::iterator::operator++()
   {
     ++m_index;
 
     return *this;
   }
 
-  string_iterator string_iterator::operator++(int)
+  string::iterator string::iterator::operator++(int)
   {
-    string_iterator copy(*this);
+    const iterator copy(*this);
 
     ++m_index;
 
     return copy;
   }
 
-  string_iterator::value_type string_iterator::operator*()
+  string::iterator::value_type string::iterator::operator*()
   {
     return m_string->at(m_index);
   }
 
-  bool string_iterator::operator==(const string_iterator& that) const
+  bool string::iterator::operator==(const iterator& that) const
   {
     return m_index == that.m_index;
   }
 
-  bool string_iterator::operator!=(const string_iterator& that) const
+  bool string::iterator::operator!=(const iterator& that) const
   {
     return m_index != that.m_index;
   }


### PR DESCRIPTION
I see no point keeping classes such as `array_iterator` and
`string_iterator` inside `plorth` namespace, when they should be
declared inside `array` and `string` classes instead.