### PR TITLE
Fix ordering in GUI stack display

### DIFF
--- a/gui/src/stack-display.cpp
+++ b/gui/src/stack-display.cpp
@@ -54,14 +54,17 @@ namespace plorth
 
     void StackDisplay::update(const context::container_type& stack)
     {
+      auto it = stack.rbegin();
+      const auto end = stack.rend();
       const auto index_column = m_columns.index_column();
       const auto value_column = m_columns.value_column();
       int index = 0;
 
       m_tree_model->clear();
 
-      for (const auto& value : stack)
+      for (; it != end; ++it)
       {
+        const auto& value = *it;
         auto row = *(m_tree_model->append());
 
         row[index_column] = ++index;


### PR DESCRIPTION
Stack display in the GUI REPL displays values from stack in wrong order,
when it should be in top-to-bottom order.