### PR TITLE
Make dictionary entries "editable" in GUI

### DIFF
--- a/gui/include/plorth/gui/dictionary-display.hpp
+++ b/gui/include/plorth/gui/dictionary-display.hpp
@@ -61,15 +61,38 @@ namespace plorth
     class DictionaryDisplay : public Gtk::Bin
     {
     public:
+      using word_activated_signal = sigc::signal<
+        void,
+        Glib::ustring,
+        Glib::ustring
+      >;
+
       explicit DictionaryDisplay();
 
       void update(const class dictionary& dictionary);
+
+      inline word_activated_signal& signal_word_activated()
+      {
+        return m_signal_word_activated;
+      }
+
+      inline const word_activated_signal& signal_word_activated() const
+      {
+        return m_signal_word_activated;
+      }
+
+    protected:
+      void on_row_activated(
+        const Gtk::TreeModel::Path& path,
+        Gtk::TreeViewColumn* column
+      );
 
     private:
       Gtk::ScrolledWindow m_scrolled_window;
       Gtk::TreeView m_tree_view;
       DictionaryDisplayColumns m_columns;
       Glib::RefPtr<Gtk::ListStore> m_tree_model;
+      word_activated_signal m_signal_word_activated;
     };
   }
 }

--- a/gui/include/plorth/gui/line-editor.hpp
+++ b/gui/include/plorth/gui/line-editor.hpp
@@ -57,6 +57,8 @@ namespace plorth
 
       void set_stack_depth_count(int stack_depth_count);
 
+      void set_text(const Glib::ustring& text);
+
       inline sigc::signal<void, Glib::ustring>& signal_line_received()
       {
         return m_signal_line_received;

--- a/gui/include/plorth/gui/window.hpp
+++ b/gui/include/plorth/gui/window.hpp
@@ -53,6 +53,10 @@ namespace plorth
       void on_show();
       void on_line_received(const Glib::ustring& line);
       void on_text_written(const Glib::ustring& text);
+      void on_word_activated(
+        const Glib::ustring& symbol,
+        const Glib::ustring& quote_source
+      );
       bool on_key_press_event(GdkEventKey* event);
 
     private:

--- a/gui/src/dictionary-display.cpp
+++ b/gui/src/dictionary-display.cpp
@@ -47,6 +47,10 @@ namespace plorth
       m_tree_view.set_model(m_tree_model);
       m_tree_view.append_column("Symbol", symbol_column);
       m_tree_view.append_column("Quote", quote_column);
+      m_tree_view.signal_row_activated().connect(sigc::mem_fun(
+        this,
+        &DictionaryDisplay::on_row_activated
+      ));
 
       m_scrolled_window.set_policy(
         Gtk::POLICY_AUTOMATIC,
@@ -75,6 +79,22 @@ namespace plorth
         );
         row[quote_column] = utils::string_convert<Glib::ustring, unistring>(
           quote ? quote->to_string() : U"(null)"
+        );
+      }
+    }
+
+    void DictionaryDisplay::on_row_activated(const Gtk::TreeModel::Path& path,
+                                             Gtk::TreeViewColumn* column)
+    {
+      const auto iter = m_tree_model->get_iter(path);
+
+      if (iter)
+      {
+        const auto& row = *iter;
+
+        m_signal_word_activated.emit(
+          row[m_columns.symbol_column()],
+          row[m_columns.quote_column()]
         );
       }
     }

--- a/gui/src/line-editor.cpp
+++ b/gui/src/line-editor.cpp
@@ -76,6 +76,11 @@ namespace plorth
       }
     }
 
+    void LineEditor::set_text(const Glib::ustring& text)
+    {
+      m_entry.set_text(text);
+    }
+
     void LineEditor::on_activate()
     {
       set_line_count(m_line_count + 1);

--- a/gui/src/window.cpp
+++ b/gui/src/window.cpp
@@ -96,6 +96,10 @@ namespace plorth
         this,
         &Window::on_text_written
       ));
+      m_dictionary_display.signal_word_activated().connect(sigc::mem_fun(
+        this,
+        &Window::on_word_activated
+      ));
     }
 
     void Window::on_show()
@@ -147,6 +151,13 @@ namespace plorth
     void Window::on_text_written(const Glib::ustring& text)
     {
       m_line_display.add_line(text, LineDisplay::LINE_TYPE_OUTPUT);
+    }
+
+    void Window::on_word_activated(const Glib::ustring& symbol,
+                                   const Glib::ustring& quote_source)
+    {
+      m_line_editor.set_text(": " + symbol + " " + quote_source + " ;");
+      m_line_editor.grab_focus();
     }
 
     bool Window::on_key_press_event(GdkEventKey* event)


### PR DESCRIPTION
Modify the dictionary display component so that it signals when an entry
has been double clicked by the user. Then attach to this signal in the
main window, so that source code of the selected word will be placed
into the line editor, thus making the dictionary entries kinda editable.