### PR TITLE
Move context away from the main window in GUI

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -19,6 +19,7 @@ INCLUDE_DIRECTORIES(
 
 ADD_EXECUTABLE(
   plorth-gui
+  src/context.cpp
   src/dictionary-display.cpp
   src/line-display.cpp
   src/line-editor.cpp

--- a/gui/include/plorth/gui/context.hpp
+++ b/gui/include/plorth/gui/context.hpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017-2018, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PLORTH_GUI_CONTEXT_HPP_GUARD
+#define PLORTH_GUI_CONTEXT_HPP_GUARD
+
+#include <plorth/plorth.hpp>
+
+#include <glibmm.h>
+
+namespace plorth
+{
+  namespace gui
+  {
+    /**
+     * Wraps Plorth runtime and execution context into single Glib object.
+     */
+    class Context : public Glib::ObjectBase
+    {
+    public:
+      using error_thrown_signal = sigc::signal<void, std::shared_ptr<error>>;
+      using text_written_signal = sigc::signal<void, Glib::ustring>;
+
+      explicit Context();
+
+      /**
+       * Returns the data stack of the execution context.
+       */
+      inline context::container_type& stack()
+      {
+        return m_context->data();
+      }
+
+      /**
+       * Returns the data stack of the execution context.
+       */
+      inline const context::container_type& stack() const
+      {
+        return m_context->data();
+      }
+
+      /**
+       * Returns local dictionary of the execution context.
+       */
+      inline class dictionary& dictionary()
+      {
+        return m_context->dictionary();
+      }
+
+      /**
+       * Returns local dictionary of the execution context.
+       */
+      inline const class dictionary& dictionary() const
+      {
+        return m_context->dictionary();
+      }
+
+      void execute(
+        const Glib::ustring& source_code,
+        const Glib::ustring& file = "<eval>",
+        int line = 1
+      );
+
+      inline error_thrown_signal& signal_error_thrown()
+      {
+        return m_signal_error_thrown;
+      }
+
+      inline const error_thrown_signal& signal_error_thrown() const
+      {
+        return m_signal_error_thrown;
+      }
+
+      inline text_written_signal& signal_text_written()
+      {
+        return m_signal_text_written;
+      }
+
+      inline const text_written_signal& signal_text_written() const
+      {
+        return m_signal_text_written;
+      }
+
+    private:
+      memory::manager m_memory_manager;
+      std::shared_ptr<runtime> m_runtime;
+      std::shared_ptr<context> m_context;
+      error_thrown_signal m_signal_error_thrown;
+      text_written_signal m_signal_text_written;
+    };
+  }
+}
+
+#endif /* !PLORTH_GUI_CONTEXT_HPP_GUARD */

--- a/gui/include/plorth/gui/window.hpp
+++ b/gui/include/plorth/gui/window.hpp
@@ -26,7 +26,7 @@
 #ifndef PLORTH_GUI_WINDOW_HPP_GUARD
 #define PLORTH_GUI_WINDOW_HPP_GUARD
 
-#include <plorth/plorth.hpp>
+#include <plorth/gui/context.hpp>
 #include <plorth/gui/dictionary-display.hpp>
 #include <plorth/gui/line-display.hpp>
 #include <plorth/gui/line-editor.hpp>
@@ -42,16 +42,15 @@ namespace plorth
     class Window : public Gtk::Window
     {
     public:
-      using text_written_signal = sigc::signal<void, Glib::ustring>;
-
       static const int DEFAULT_WIDTH;
       static const int DEFAULT_HEIGHT;
 
-      explicit Window();
+      explicit Window(const Glib::RefPtr<Context>& context);
 
     protected:
       void on_show();
       void on_line_received(const Glib::ustring& line);
+      void on_error_thrown(const std::shared_ptr<error>& error);
       void on_text_written(const Glib::ustring& text);
       void on_word_activated(
         const Glib::ustring& symbol,
@@ -60,11 +59,9 @@ namespace plorth
       bool on_key_press_event(GdkEventKey* event);
 
     private:
-      memory::manager m_memory_manager;
-      const std::shared_ptr<runtime> m_runtime;
-      const std::shared_ptr<context> m_context;
-      unistring m_source;
-      std::stack<unichar> m_open_braces;
+      Glib::RefPtr<Context> m_context;
+      Glib::ustring m_source;
+      std::stack<char32_t> m_open_braces;
       Gtk::Box m_box;
       LineDisplay m_line_display;
       Gtk::Notebook m_notebook;
@@ -72,7 +69,6 @@ namespace plorth
       DictionaryDisplay m_dictionary_display;
       Gtk::Paned m_paned;
       LineEditor m_line_editor;
-      text_written_signal m_text_written_signal;
     };
   }
 }

--- a/gui/src/context.cpp
+++ b/gui/src/context.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017-2018, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <plorth/gui/context.hpp>
+#include "./utils.hpp"
+
+namespace plorth
+{
+  namespace gui
+  {
+#if PLORTH_ENABLE_MODULES
+    static void scan_module_path(const std::shared_ptr<runtime>&);
+#endif
+
+    namespace
+    {
+      class custom_output : public io::output
+      {
+      public:
+        explicit custom_output(Context::text_written_signal signal)
+          : m_signal(signal) {}
+
+        void write(const unistring& text)
+        {
+          m_signal.emit(utils::string_convert<Glib::ustring, unistring>(text));
+        }
+
+      private:
+        const Context::text_written_signal m_signal;
+      };
+    }
+
+    Context::Context()
+      : m_runtime(runtime::make(m_memory_manager))
+      , m_context(context::make(m_runtime))
+    {
+      const auto output = m_runtime->value<custom_output>(
+        m_signal_text_written
+      );
+
+      m_runtime->output() = output;
+      m_runtime->input() = io::input::dummy(m_memory_manager);
+
+#if PLORTH_ENABLE_MODULES
+      scan_module_path(m_runtime);
+#endif
+    }
+
+    void Context::execute(const Glib::ustring& source_code,
+                          const Glib::ustring& file,
+                          int line)
+    {
+      auto script = m_context->compile(
+        utils::string_convert<unistring, Glib::ustring>(source_code),
+        utils::string_convert<unistring, Glib::ustring>(file),
+        line
+      );
+
+      if (!script || !script->call(m_context))
+      {
+        auto error = m_context->error();
+
+        m_context->clear_error();
+        if (error)
+        {
+          m_signal_error_thrown.emit(error);
+        }
+      }
+    }
+
+#if PLORTH_ENABLE_MODULES
+    static void scan_module_path(const std::shared_ptr<runtime>& runtime)
+    {
+#if defined(_WIN32)
+      static const unichar path_separator = ';';
+#else
+      static const unichar path_separator = ':';
+#endif
+      auto& module_paths = runtime->module_paths();
+      const char* begin = std::getenv("PLORTHPATH");
+      const char* end = begin;
+
+      if (end)
+      {
+        for (; *end; ++end)
+        {
+          if (*end != path_separator)
+          {
+            continue;
+          }
+
+          if (end - begin > 0)
+          {
+            module_paths.push_back(utf8_decode(std::string(begin, end - begin)));
+          }
+          begin = end + 1;
+        }
+
+        if (end - begin > 0)
+        {
+          module_paths.push_back(utf8_decode(std::string(begin, end - begin)));
+        }
+      }
+
+#if defined(PLORTH_RUNTIME_LIBRARY_PATH)
+      if (module_paths.empty())
+      {
+        module_paths.push_back(PLORTH_RUNTIME_LIBRARY_PATH);
+      }
+#endif
+    }
+#endif
+  }
+}

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -1,9 +1,37 @@
+/*
+ * Copyright (c) 2017-2018, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #include <plorth/gui/window.hpp>
 
 int main(int argc, char** argv)
 {
   auto app = Gtk::Application::create(argc, argv, "org.plorth.gui");
-  plorth::gui::Window window;
+  auto context = Glib::RefPtr<plorth::gui::Context>(
+    new plorth::gui::Context()
+  );
+  plorth::gui::Window window(context);
 
   return app->run(window);
 }

--- a/gui/src/utils.hpp
+++ b/gui/src/utils.hpp
@@ -27,7 +27,7 @@
 #define PLORTH_GUI_UTILS_HPP_GUARD
 
 #include <plorth/plorth.hpp>
-#include <glibmm.h>
+#include <pangomm.h>
 
 namespace plorth
 {


### PR DESCRIPTION
Moving the runtime and execution context into separate class away from
the main window in the GUI makes the code more cleaner, and hopefully
even reusable.