### PR TITLE
Use linenoise library for improved CLI UX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plorth/ext/linenoise"]
+    path = plorth/ext/linenoise
+    url = https://github.com/antirez/linenoise

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Plorth has no dependencies. Only C++11 capable compiler and [CMake] are
 required to compile Plorth interpreter.
 
 ```bash
-mkdir build
-cd build
-cmake ..
-make
+$ git submodule update --init
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
 ```
 
 After the interpreter has been successfully compiled, you can run the `plorth`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,13 @@ by executing the following command:
 $ git clone https://github.com/RauliL/plorth.git
 ```
 
+If you are planning on using the command line interface, you will also need to
+execute the following command to pull in external dependencies used by it:
+
+```bash
+$ git submodule --init
+```
+
 ## Compiling
 
 After you have cloned the source code from GitHub, you need to compile the

--- a/plorth/CMakeLists.txt
+++ b/plorth/CMakeLists.txt
@@ -1,10 +1,14 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 PROJECT(plorth-cli C CXX)
 
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../libplorth/include)
+INCLUDE_DIRECTORIES(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../libplorth/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/ext/linenoise
+)
 
 ADD_EXECUTABLE(
   plorth-cli
+  ext/linenoise/linenoise.c
   src/main.cpp
   src/repl.cpp
 )


### PR DESCRIPTION
Plorth doesn't have proper CLI right now, instead it reads user input with `std::getline` function, which doesn't provide things you would except from a modern command line application, such as proper keybindings and history. For a while, I thought about implementing such functionality with GNU readline library, but instead I chose linenoise instead, which is minimal embeddable readline replacement that provides all the functionality I need without any unnecessary bloat.