### PR TITLE
Redesign object class

### DIFF
--- a/libplorth/include/plorth/context.hpp
+++ b/libplorth/include/plorth/context.hpp
@@ -234,13 +234,19 @@ namespace plorth
      * Constructs array from given sequence of values and pushes it into the
      * data stack.
      */
+    void push_array(const std::vector<std::shared_ptr<value>>& elements);
+
+    /**
+     * Constructs array from given sequence of values and pushes it into the
+     * data stack.
+     */
     void push_array(array::const_pointer elements, array::size_type size);
 
     /**
      * Constructs object from given properties and pushes it into the data
      * stack.
      */
-    void push_object(const object::container_type& properties);
+    void push_object(const std::vector<object::value_type>& properties);
 
     /**
      * Constructs symbol from given identifier and pushes it onto the data

--- a/libplorth/include/plorth/dictionary.hpp
+++ b/libplorth/include/plorth/dictionary.hpp
@@ -43,6 +43,7 @@ namespace plorth
     using value_type = std::shared_ptr<word>;
     /** Underlying container type. */
     using container_type = std::unordered_map<unistring, value_type>;
+    using size_type = container_type::size_type;
 
     /**
      * Constructs new empty dictionary.
@@ -58,6 +59,14 @@ namespace plorth
      * Copies contents of another dictionary into this one.
      */
     dictionary& operator=(const dictionary& that);
+
+    /**
+     * Returns the number of words the dictionary contains.
+     */
+    inline size_type size() const
+    {
+      return m_words.size();
+    }
 
     /**
      * Returns words from the dictionary as iterable vector.

--- a/libplorth/include/plorth/runtime.hpp
+++ b/libplorth/include/plorth/runtime.hpp
@@ -43,6 +43,10 @@ namespace plorth
     using prototype_definition = std::vector<
       std::pair<const char32_t*, quote::callback>
     >;
+    using module_container = std::unordered_map<
+      unistring,
+      std::shared_ptr<class object>
+    >;
 #if PLORTH_ENABLE_SYMBOL_CACHE
     using symbol_cache = std::unordered_map<
       unistring,
@@ -164,7 +168,7 @@ namespace plorth
     /**
      * Returns the container which the runtime uses to cache imported modules.
      */
-    inline object::container_type& imported_modules()
+    inline module_container& imported_modules()
     {
       return m_imported_modules;
     }
@@ -172,7 +176,7 @@ namespace plorth
     /**
      * Returns the container which the runtime uses to cache imported modules.
      */
-    inline const object::container_type& imported_modules() const
+    inline const module_container& imported_modules() const
     {
       return m_imported_modules;
     }
@@ -244,6 +248,16 @@ namespace plorth
      */
     std::shared_ptr<class array> array(array::const_pointer elements,
                                        array::size_type size);
+
+    /**
+     * Constructs object value from given properties.
+     *
+     * \param properties Properties to construct object from.
+     * \return           Reference to the created object value.
+     */
+    std::shared_ptr<class object> object(
+      const std::vector<object::value_type>& properties
+    );
 
     /**
      * Constructs string value from given Unicode string.
@@ -342,7 +356,7 @@ namespace plorth
     /**
      * Returns prototype for array values.
      */
-    inline const std::shared_ptr<object>& array_prototype() const
+    inline const std::shared_ptr<class object>& array_prototype() const
     {
       return m_array_prototype;
     }
@@ -350,7 +364,7 @@ namespace plorth
     /**
      * Returns prototype for boolean values.
      */
-    inline const std::shared_ptr<object>& boolean_prototype() const
+    inline const std::shared_ptr<class object>& boolean_prototype() const
     {
       return m_boolean_prototype;
     }
@@ -358,7 +372,7 @@ namespace plorth
     /**
      * Returns prototype for error values.
      */
-    inline const std::shared_ptr<object>& error_prototype() const
+    inline const std::shared_ptr<class object>& error_prototype() const
     {
       return m_error_prototype;
     }
@@ -366,7 +380,7 @@ namespace plorth
     /**
      * Returns prototype for number values.
      */
-    inline const std::shared_ptr<object>& number_prototype() const
+    inline const std::shared_ptr<class object>& number_prototype() const
     {
       return m_number_prototype;
     }
@@ -374,7 +388,7 @@ namespace plorth
     /**
      * Returns prototype for objects.
      */
-    inline const std::shared_ptr<object>& object_prototype() const
+    inline const std::shared_ptr<class object>& object_prototype() const
     {
       return m_object_prototype;
     }
@@ -382,7 +396,7 @@ namespace plorth
     /**
      * Returns prototype for quotes.
      */
-    inline const std::shared_ptr<object>& quote_prototype() const
+    inline const std::shared_ptr<class object>& quote_prototype() const
     {
       return m_quote_prototype;
     }
@@ -390,7 +404,7 @@ namespace plorth
     /**
      * Returns prototype for string values.
      */
-    inline const std::shared_ptr<object>& string_prototype() const
+    inline const std::shared_ptr<class object>& string_prototype() const
     {
       return m_string_prototype;
     }
@@ -398,7 +412,7 @@ namespace plorth
     /**
      * Returns prototype for symbols.
      */
-    inline const std::shared_ptr<object>& symbol_prototype() const
+    inline const std::shared_ptr<class object>& symbol_prototype() const
     {
       return m_symbol_prototype;
     }
@@ -406,7 +420,7 @@ namespace plorth
     /**
      * Returns prototype for words.
      */
-    inline const std::shared_ptr<object>& word_prototype() const
+    inline const std::shared_ptr<class object>& word_prototype() const
     {
       return m_word_prototype;
     }
@@ -434,29 +448,29 @@ namespace plorth
     /** Shared instance of false boolean value. */
     std::shared_ptr<class boolean> m_false_value;
     /** Prototype for array values. */
-    std::shared_ptr<object> m_array_prototype;
+    std::shared_ptr<class object> m_array_prototype;
     /** Prototype for boolean values. */
-    std::shared_ptr<object> m_boolean_prototype;
+    std::shared_ptr<class object> m_boolean_prototype;
     /** Prototype for error values. */
-    std::shared_ptr<object> m_error_prototype;
+    std::shared_ptr<class object> m_error_prototype;
     /** Prototype for number values. */
-    std::shared_ptr<object> m_number_prototype;
+    std::shared_ptr<class object> m_number_prototype;
     /** Prototype for objects. */
-    std::shared_ptr<object> m_object_prototype;
+    std::shared_ptr<class object> m_object_prototype;
     /** Prototype for quotes. */
-    std::shared_ptr<object> m_quote_prototype;
+    std::shared_ptr<class object> m_quote_prototype;
     /** Prototype for string values. */
-    std::shared_ptr<object> m_string_prototype;
+    std::shared_ptr<class object> m_string_prototype;
     /** Prototype for symbol values. */
-    std::shared_ptr<object> m_symbol_prototype;
+    std::shared_ptr<class object> m_symbol_prototype;
     /** Prototype for words. */
-    std::shared_ptr<object> m_word_prototype;
+    std::shared_ptr<class object> m_word_prototype;
     /** List of command line arguments given for the interpreter. */
     std::vector<unistring> m_arguments;
     /** List of file system paths where to look modules from. */
     std::vector<unistring> m_module_paths;
     /** Container for already imported modules. */
-    object::container_type m_imported_modules;
+    module_container m_imported_modules;
 #if PLORTH_ENABLE_SYMBOL_CACHE
     /** Cache for symbols used by the runtime. */
     symbol_cache m_symbol_cache;

--- a/libplorth/src/compiler.cpp
+++ b/libplorth/src/compiler.cpp
@@ -495,7 +495,7 @@ namespace plorth
       std::shared_ptr<object> compile_object(context* ctx)
       {
         struct position position;
-        object::container_type properties;
+        std::vector<object::value_type> properties;
 
         if (skip_whitespace())
         {
@@ -572,7 +572,7 @@ namespace plorth
               return std::shared_ptr<object>();
             }
 
-            properties[key->to_string()] = value;
+            properties.push_back({ key->to_string(), value });
 
             if (skip_whitespace() || (!peek(',') && !peek('}')))
             {
@@ -589,7 +589,7 @@ namespace plorth
           }
         }
 
-        return ctx->runtime()->value<object>(properties);
+        return ctx->runtime()->object(properties);
       }
 
       bool compile_escape_sequence(context* ctx, unistring& buffer)

--- a/libplorth/src/context.cpp
+++ b/libplorth/src/context.cpp
@@ -83,19 +83,26 @@ namespace plorth
     push(m_runtime->string(value.c_str(), value.length()));
   }
 
-  void context::push_string(string::const_pointer chars, string::size_type length)
+  void context::push_string(string::const_pointer chars,
+                            string::size_type length)
   {
     push(m_runtime->string(chars, length));
   }
 
-  void context::push_array(array::const_pointer elements, array::size_type size)
+  void context::push_array(const std::vector<std::shared_ptr<value>>& elements)
+  {
+    push_array(elements.data(), elements.size());
+  }
+
+  void context::push_array(array::const_pointer elements,
+                           array::size_type size)
   {
     push(m_runtime->array(elements, size));
   }
 
-  void context::push_object(const object::container_type& properties)
+  void context::push_object(const std::vector<object::value_type>& properties)
   {
-    push(m_runtime->value<object>(properties));
+    push(m_runtime->object(properties));
   }
 
   void context::push_symbol(const unistring& id)

--- a/libplorth/src/eval.cpp
+++ b/libplorth/src/eval.cpp
@@ -109,9 +109,10 @@ namespace plorth
                        const std::shared_ptr<object>& obj,
                        std::shared_ptr<value>& slot)
   {
-    object::container_type properties;
+    std::vector<object::value_type> properties;
 
-    for (const auto& property : obj->properties())
+    properties.reserve(obj->size());
+    for (const auto& property : obj->entries())
     {
       std::shared_ptr<value> value_slot;
 
@@ -119,9 +120,9 @@ namespace plorth
       {
         return false;
       }
-      properties[property.first] = value_slot;
+      properties.push_back({ property.first, value_slot });
     }
-    slot = ctx->runtime()->value<object>(properties);
+    slot = ctx->runtime()->object(properties);
 
     return true;
   }

--- a/libplorth/src/globals.cpp
+++ b/libplorth/src/globals.cpp
@@ -681,7 +681,7 @@ namespace plorth
 
       ctx->push(val);
 
-      if (!obj->property(runtime, U"prototype", prototype1, false) ||
+      if (!obj->own_property(U"prototype", prototype1) ||
           !prototype1 ||
           !prototype1->is(value::type_object) ||
           !prototype2)
@@ -695,10 +695,10 @@ namespace plorth
         return;
       }
 
-      while (std::static_pointer_cast<object>(prototype2)->property(runtime,
-                                                                    U"__proto__",
-                                                                    prototype2,
-                                                                    false) &&
+      while (std::static_pointer_cast<object>(prototype2)->own_property(
+              U"__proto__",
+              prototype2
+             ) &&
              prototype2 &&
              prototype2->is(value::type_object))
       {
@@ -1102,11 +1102,13 @@ namespace plorth
    */
   static void w_globals(const std::shared_ptr<context>& ctx)
   {
-    object::container_type result;
+    const auto& dictionary = ctx->runtime()->dictionary();
+    std::vector<object::value_type> result;
 
-    for (const auto& word : ctx->runtime()->dictionary().words())
+    result.reserve(dictionary.size());
+    for (const auto& word : dictionary.words())
     {
-      result[word->symbol()->id()] = word->quote();
+      result.push_back({ word->symbol()->id(), word->quote() });
     }
     ctx->push_object(result);
   }
@@ -1121,11 +1123,13 @@ namespace plorth
    */
   static void w_locals(const std::shared_ptr<context>& ctx)
   {
-    object::container_type result;
+    const auto& dictionary = ctx->dictionary();
+    std::vector<object::value_type> result;
 
-    for (const auto& word : ctx->dictionary().words())
+    result.reserve(dictionary.size());
+    for (const auto& word : dictionary.words())
     {
-      result[word->symbol()->id()] = word->quote();
+      result.push_back({ word->symbol()->id(), word->quote() });
     }
     ctx->push_object(result);
   }

--- a/libplorth/src/module.cpp
+++ b/libplorth/src/module.cpp
@@ -43,7 +43,7 @@ namespace plorth
 #if PLORTH_ENABLE_MODULES
     unistring resolved_path;
     auto& imported_modules = m_runtime->imported_modules();
-    object::container_type::iterator entry;
+    runtime::module_container::iterator entry;
     std::shared_ptr<object> module;
 
     // First attempt to resolve the module path into actual file system path.
@@ -75,7 +75,7 @@ namespace plorth
 
     // Transfer all exported words from the module into the calling execution
     // context.
-    for (const auto& property : module->properties())
+    for (const auto& property : module->entries())
     {
       if (property.second && property.second->is(value::type_quote))
       {
@@ -103,7 +103,7 @@ namespace plorth
     unistring source;
     std::shared_ptr<quote> compiled_module;
     std::shared_ptr<context> module_ctx;
-    object::container_type result;
+    std::vector<object::value_type> result;
 
     if (!is.good())
     {
@@ -153,10 +153,10 @@ namespace plorth
     // Finally convert the module into object.
     for (const auto& word : module_ctx->dictionary().words())
     {
-      result[word->symbol()->id()] = word->quote();
+      result.push_back({ word->symbol()->id(), word->quote() });
     }
 
-    return ctx->runtime()->value<object>(result);
+    return ctx->runtime()->object(result);
   }
 
   static bool is_absolute_path(const unistring& path)

--- a/libplorth/src/value.cpp
+++ b/libplorth/src/value.cpp
@@ -74,50 +74,50 @@ namespace plorth
   {
     switch (type())
     {
-      case type_null:
-        return runtime->object_prototype();
+    case type_null:
+      return runtime->object_prototype();
 
-      case type_boolean:
-        return runtime->boolean_prototype();
+    case type_boolean:
+      return runtime->boolean_prototype();
 
-      case type_number:
-        return runtime->number_prototype();
+    case type_number:
+      return runtime->number_prototype();
 
-      case type_string:
-        return runtime->string_prototype();
+    case type_string:
+      return runtime->string_prototype();
 
-      case type_array:
-        return runtime->array_prototype();
+    case type_array:
+      return runtime->array_prototype();
 
-      case type_symbol:
-        return runtime->symbol_prototype();
+    case type_symbol:
+      return runtime->symbol_prototype();
 
-      case type_quote:
-        return runtime->quote_prototype();
+    case type_quote:
+      return runtime->quote_prototype();
 
-      case type_word:
-        return runtime->word_prototype();
+    case type_word:
+      return runtime->word_prototype();
 
-      case type_error:
-        return runtime->error_prototype();
+    case type_error:
+      return runtime->error_prototype();
 
-      case type_object:
+    case type_object:
+      {
+        std::shared_ptr<value> slot;
+
+        if (static_cast<const object*>(this)->own_property(U"__proto__", slot))
         {
-          const auto& properties = static_cast<const object*>(this)->properties();
-          const auto property = properties.find(U"__proto__");
-
-          if (property == std::end(properties))
+          if (slot && slot->is(type_object))
           {
-            return runtime->object_prototype();
-          }
-          else if (property->second && property->second->is(type_object))
-          {
-            return std::static_pointer_cast<object>(property->second);
+            return std::static_pointer_cast<object>(slot);
           } else {
             return std::shared_ptr<object>();
           }
         }
-        break;
+
+        return runtime->object_prototype();
+      }
+      break;
     }
 
     return std::shared_ptr<object>(); // Just to make GCC happy.

--- a/tests/test-object.plorth
+++ b/tests/test-object.plorth
@@ -70,7 +70,7 @@ test-case
 "delete"
 [
   ( "a" { "a": 1 } delete {} = ),
-  ( ( "a" {} delete ) ( drop true ) ( false ) try-else ),
+  ( ( "a" {} delete ) ( drop true ) ( false ) try-else nip ),
 ]
 test-case
 


### PR DESCRIPTION
Hide implementation details on class `object`, just like have been previously done to `array` and `string` classes. They do not need to be part of the public API and allows us to do various optimizations.