### PR TITLE
Use enum classes everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,46 @@
 language: cpp
-compiler:
-  - clang
-  - gcc
-script: ./scripts/run-tests.sh
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+before_install:
+  - eval "${MATRIX_EVAL}"
+script:
+  - ./scripts/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
-      env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
             - g++-6
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
-PROJECT(plorth-gui C CXX)
+PROJECT(plorth-gui CXX)
 
 FIND_PACKAGE(PkgConfig)
 

--- a/libplorth/CMakeLists.txt
+++ b/libplorth/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
-PROJECT(libplorth C CXX)
+PROJECT(libplorth CXX)
 
 INCLUDE(CheckIncludeFile)
 INCLUDE(CheckFunctionExists)

--- a/libplorth/include/plorth/io-input.hpp
+++ b/libplorth/include/plorth/io-input.hpp
@@ -44,14 +44,14 @@ namespace plorth
       /**
        * Represents results of read operation.
        */
-      enum result
+      enum class result
       {
         /** Reading from standard input stream was successful. */
-        result_ok,
+        ok = 1,
         /** End of input was encountered. */
-        result_eof,
+        eof = -1,
         /** Unicode decoding error was encountered. */
-        result_failure
+        failure = 0
       };
 
       /**

--- a/libplorth/include/plorth/value-array.hpp
+++ b/libplorth/include/plorth/value-array.hpp
@@ -59,7 +59,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_array;
+      return type::array;
     }
 
     bool equals(const std::shared_ptr<value>& that) const;

--- a/libplorth/include/plorth/value-boolean.hpp
+++ b/libplorth/include/plorth/value-boolean.hpp
@@ -42,7 +42,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_boolean;
+      return type::boolean;
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;

--- a/libplorth/include/plorth/value-error.hpp
+++ b/libplorth/include/plorth/value-error.hpp
@@ -34,24 +34,24 @@ namespace plorth
   class error : public value
   {
   public:
-    enum code
+    enum class code
     {
       /** Syntax error. */
-      code_syntax = 1,
+      syntax = 1,
       /** Reference error. */
-      code_reference = 2,
+      reference = 2,
       /** Type error. */
-      code_type = 3,
+      type = 3,
       /** Value error. */
-      code_value = 4,
+      value = 4,
       /** Range error. */
-      code_range = 5,
+      range = 5,
       /** Import error. */
-      code_import = 6,
+      import = 6,
       /** I/O error. */
-      code_io = 7,
+      io = 7,
       /** Unknown error. */
-      code_unknown = 100
+      unknown = 100
     };
 
     /**
@@ -62,9 +62,11 @@ namespace plorth
      * \param position Optional position in source code where the error
      *                 occurred.
      */
-    explicit error(enum code code,
-                   const unistring& message,
-                   const struct position* position = nullptr);
+    explicit error(
+      enum code code,
+      const unistring& message,
+      const struct position* position = nullptr
+    );
 
     ~error();
 
@@ -99,7 +101,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_error;
+      return type::error;
     }
 
     bool equals(const std::shared_ptr<value>& that) const;

--- a/libplorth/include/plorth/value-number.hpp
+++ b/libplorth/include/plorth/value-number.hpp
@@ -48,10 +48,10 @@ namespace plorth
     /**
      * Enumeration for different supported number types.
      */
-    enum number_type
+    enum class number_type
     {
-      number_type_int,
-      number_type_real
+      integer = 0,
+      real = 1
     };
 
     /**
@@ -79,7 +79,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_number;
+      return type::number;
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;

--- a/libplorth/include/plorth/value-object.hpp
+++ b/libplorth/include/plorth/value-object.hpp
@@ -128,7 +128,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_object;
+      return type::object;
     }
 
     bool equals(const std::shared_ptr<value>& that) const;

--- a/libplorth/include/plorth/value-quote.hpp
+++ b/libplorth/include/plorth/value-quote.hpp
@@ -45,10 +45,10 @@ namespace plorth
     /**
      * Enumeration for different supported quote types.
      */
-    enum quote_type
+    enum class quote_type
     {
-      quote_type_native,
-      quote_type_compiled
+      native = 0,
+      compiled = 1
     };
 
     /**
@@ -75,7 +75,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_quote;
+      return type::quote;
     }
 
     unistring to_source() const;

--- a/libplorth/include/plorth/value-string.hpp
+++ b/libplorth/include/plorth/value-string.hpp
@@ -61,7 +61,7 @@ namespace plorth
 
     enum type type() const
     {
-      return type_string;
+      return type::string;
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;

--- a/libplorth/include/plorth/value-symbol.hpp
+++ b/libplorth/include/plorth/value-symbol.hpp
@@ -80,7 +80,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_symbol;
+      return type::symbol;
     }
 
     bool equals(const std::shared_ptr<value>& that) const;

--- a/libplorth/include/plorth/value-word.hpp
+++ b/libplorth/include/plorth/value-word.hpp
@@ -64,7 +64,7 @@ namespace plorth
 
     inline enum type type() const
     {
-      return type_word;
+      return type::word;
     }
 
     bool equals(const std::shared_ptr<value>& that) const;

--- a/libplorth/include/plorth/value.hpp
+++ b/libplorth/include/plorth/value.hpp
@@ -43,28 +43,28 @@ namespace plorth
     /**
      * Enumeration of different supported value types.
      */
-    enum type
+    enum class type
     {
       /** Value for null. */
-      type_null,
+      null = 0,
       /** Boolean values. */
-      type_boolean,
+      boolean = 1,
       /** Number (floating point) values. */
-      type_number,
+      number = 2,
       /** String (Unicode) values. */
-      type_string,
+      string = 3,
       /** Array values. */
-      type_array,
+      array = 4,
       /** Other type of objects. */
-      type_object,
+      object = 5,
       /** Symbols. */
-      type_symbol,
+      symbol = 6,
       /** Quotes. */
-      type_quote,
+      quote = 7,
       /** Words. */
-      type_word,
+      word = 8,
       /** Errors. */
-      type_error
+      error = 9
     };
 
     /**
@@ -83,12 +83,20 @@ namespace plorth
     static unistring type_description(enum type type);
 
     /**
+     * Tests whether given value is of given type.
+     */
+    static inline bool is(const std::shared_ptr<value>& val, enum type t)
+    {
+      return val ? val->is(t) : t == type::null;
+    }
+
+    /**
      * Tests whether the value is of given type.
      */
     inline bool is(enum type t) const
     {
       return type() == t;
-    };
+    }
 
     /**
      * Determines prototype object of the value, based on it's type. If the

--- a/libplorth/src/compiler.cpp
+++ b/libplorth/src/compiler.cpp
@@ -170,7 +170,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing value.",
             &m_position
           );
@@ -209,7 +209,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing symbol.",
             &m_position
           );
@@ -222,7 +222,7 @@ namespace plorth
         if (!unichar_isword(peek()))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing symbol.",
             &m_position
           );
@@ -249,7 +249,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing word.",
             &m_position
           );
@@ -262,7 +262,7 @@ namespace plorth
         if (!peek_read(':'))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing word.",
             &position
           );
@@ -280,7 +280,7 @@ namespace plorth
           if (skip_whitespace())
           {
             ctx->error(
-              error::code_syntax,
+              error::code::syntax,
               U"Unterminated word; Missing `;'.",
               &position
             );
@@ -312,7 +312,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing quote.",
             &m_position
           );
@@ -325,7 +325,7 @@ namespace plorth
         if (!peek_read('('))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing quote.",
             &position
           );
@@ -338,7 +338,7 @@ namespace plorth
           if (skip_whitespace())
           {
             ctx->error(
-              error::code_syntax,
+              error::code::syntax,
               U"Unterminated quote; Missing `)'.",
               &position
             );
@@ -371,7 +371,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing string.",
             &m_position
           );
@@ -384,7 +384,7 @@ namespace plorth
         if (!peek_read('"', separator) && !peek_read('\'', separator))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing string.",
             &position
           );
@@ -397,7 +397,7 @@ namespace plorth
           if (eof())
           {
             ctx->error(
-              error::code_syntax,
+              error::code::syntax,
               unistring(U"Unterminated string; Missing `") + separator + U"'",
               &position
             );
@@ -430,7 +430,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing array.",
             &m_position
           );
@@ -443,7 +443,7 @@ namespace plorth
         if (!peek_read('['))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing array.",
             &position
           );
@@ -456,7 +456,7 @@ namespace plorth
           if (skip_whitespace())
           {
             ctx->error(
-              error::code_syntax,
+              error::code::syntax,
               U"Unterminated array; Missing `]'.",
               &position
             );
@@ -477,7 +477,7 @@ namespace plorth
             if (skip_whitespace() || (!peek(',') && !peek(']')))
             {
               ctx->error(
-                error::code_syntax,
+                error::code::syntax,
                 U"Unterminated array; Missing `]'.",
                 &position
               );
@@ -500,7 +500,7 @@ namespace plorth
         if (skip_whitespace())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing object.",
             &m_position
           );
@@ -513,7 +513,7 @@ namespace plorth
         if (!peek_read('{'))
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected input; Missing object.",
             &position
           );
@@ -526,7 +526,7 @@ namespace plorth
           if (skip_whitespace())
           {
             ctx->error(
-              error::code_syntax,
+              error::code::syntax,
               U"Unterminated object; Missing `}'.",
               &position
             );
@@ -548,7 +548,7 @@ namespace plorth
             if (skip_whitespace())
             {
               ctx->error(
-                error::code_syntax,
+                error::code::syntax,
                 U"Unterminated object; Missing `}'.",
                 &position
               );
@@ -559,7 +559,7 @@ namespace plorth
             if (!peek_read(':'))
             {
               ctx->error(
-                error::code_syntax,
+                error::code::syntax,
                 U"Missing `:' after property key.",
                 &m_position
               );
@@ -577,7 +577,7 @@ namespace plorth
             if (skip_whitespace() || (!peek(',') && !peek('}')))
             {
               ctx->error(
-                error::code_syntax,
+                error::code::syntax,
                 U"Unterminated object; Missing `}'.",
                 &position
               );
@@ -599,7 +599,7 @@ namespace plorth
         if (eof())
         {
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Unexpected end of input; Missing escape sequence.",
             &m_position
           );
@@ -647,7 +647,7 @@ namespace plorth
               if (eof())
               {
                 ctx->error(
-                  error::code_syntax,
+                  error::code::syntax,
                   U"Unterminated escape sequence.",
                   &position
                 );
@@ -657,7 +657,7 @@ namespace plorth
               else if (!std::isxdigit(peek()))
               {
                 ctx->error(
-                  error::code_syntax,
+                  error::code::syntax,
                   U"Illegal Unicode hex escape sequence.",
                   &position
                 );
@@ -680,7 +680,7 @@ namespace plorth
             if (!unichar_validate(result))
             {
               ctx->error(
-                error::code_syntax,
+                error::code::syntax,
                 U"Illegal Unicode hex escape sequence.",
                 &position
               );
@@ -694,7 +694,7 @@ namespace plorth
 
         default:
           ctx->error(
-            error::code_syntax,
+            error::code::syntax,
             U"Illegal escape sequence in string literal.",
             &position
           );

--- a/libplorth/src/context.cpp
+++ b/libplorth/src/context.cpp
@@ -129,7 +129,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, U"Stack underflow.");
+    error(error::code::range, U"Stack underflow.");
 
     return false;
   }
@@ -140,12 +140,14 @@ namespace plorth
     {
       const auto& value = m_data.back();
 
-      if ((!value && type != value::type_null) || (value && !value->is(type)))
+      if (!value::is(value, type))
       {
         error(
-          error::code_type,
-          U"Expected " + value::type_description(type) + U", got " +
-          (value ? value->type_description().c_str() : U"null") +
+          error::code::type,
+          U"Expected " +
+          value::type_description(type) +
+          U", got " +
+          value::type_description(value ? value->type() : value::type::null) +
           U" instead."
         );
 
@@ -155,7 +157,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, U"Stack underflow.");
+    error(error::code::range, U"Stack underflow.");
 
     return false;
   }
@@ -169,7 +171,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, U"Stack underflow.");
+    error(error::code::range, U"Stack underflow.");
 
     return false;
   }
@@ -179,12 +181,14 @@ namespace plorth
     if (!m_data.empty())
     {
       slot = m_data.back();
-      if ((!slot && type != value::type_null) || (slot && !slot->is(type)))
+      if (!value::is(slot, type))
       {
         error(
-          error::code_type,
-          U"Expected " + value::type_description(type) + U", got " +
-          (slot ? slot->type_description().c_str() : U"null") +
+          error::code::type,
+          U"Expected " +
+          value::type_description(type) +
+          U", got " +
+          value::type_description(slot ? slot->type() : value::type::null) +
           U" instead."
         );
 
@@ -194,7 +198,7 @@ namespace plorth
 
       return true;
     }
-    error(error::code_range, U"Stack underflow.");
+    error(error::code::range, U"Stack underflow.");
 
     return false;
   }
@@ -203,7 +207,7 @@ namespace plorth
   {
     std::shared_ptr<class value> value;
 
-    if (!pop(value, value::type_boolean))
+    if (!pop(value, value::type::boolean))
     {
       return false;
     }
@@ -230,36 +234,36 @@ namespace plorth
 
   bool context::pop_number(std::shared_ptr<number>& slot)
   {
-    return typed_context_pop<number>(this, slot, value::type_number);
+    return typed_context_pop<number>(this, slot, value::type::number);
   }
 
   bool context::pop_string(std::shared_ptr<string>& slot)
   {
-    return typed_context_pop<string>(this, slot, value::type_string);
+    return typed_context_pop<string>(this, slot, value::type::string);
   }
 
   bool context::pop_array(std::shared_ptr<array>& slot)
   {
-    return typed_context_pop<array>(this, slot, value::type_array);
+    return typed_context_pop<array>(this, slot, value::type::array);
   }
 
   bool context::pop_object(std::shared_ptr<object>& slot)
   {
-    return typed_context_pop<object>(this, slot, value::type_object);
+    return typed_context_pop<object>(this, slot, value::type::object);
   }
 
   bool context::pop_quote(std::shared_ptr<quote>& slot)
   {
-    return typed_context_pop<quote>(this, slot, value::type_quote);
+    return typed_context_pop<quote>(this, slot, value::type::quote);
   }
 
   bool context::pop_symbol(std::shared_ptr<symbol>& slot)
   {
-    return typed_context_pop<symbol>(this, slot, value::type_symbol);
+    return typed_context_pop<symbol>(this, slot, value::type::symbol);
   }
 
   bool context::pop_word(std::shared_ptr<word>& slot)
   {
-    return typed_context_pop<word>(this, slot, value::type_word);
+    return typed_context_pop<word>(this, slot, value::type::word);
   }
 }

--- a/libplorth/src/eval.cpp
+++ b/libplorth/src/eval.cpp
@@ -56,16 +56,16 @@ namespace plorth
     }
     switch (val->type())
     {
-      case value::type_array:
+      case value::type::array:
         return eval_ary(ctx, std::static_pointer_cast<array>(val), slot);
 
-      case value::type_object:
+      case value::type::object:
         return eval_obj(ctx, std::static_pointer_cast<object>(val), slot);
 
-      case value::type_symbol:
+      case value::type::symbol:
         return eval_sym(ctx, std::static_pointer_cast<symbol>(val), slot);
 
-      case value::type_word:
+      case value::type::word:
         return eval_wrd(ctx, std::static_pointer_cast<word>(val), slot);
 
       default:
@@ -154,7 +154,7 @@ namespace plorth
       slot = ctx->runtime()->number(id);
     } else {
       ctx->error(
-        error::code_syntax,
+        error::code::syntax,
         U"Unexpected `" + id + U"'; Missing value."
       );
 
@@ -169,7 +169,7 @@ namespace plorth
                        std::shared_ptr<value>& slot)
   {
     ctx->error(
-      error::code_syntax,
+      error::code::syntax,
       U"Unexpected word declaration; Missing value."
     );
 

--- a/libplorth/src/exec.cpp
+++ b/libplorth/src/exec.cpp
@@ -47,10 +47,10 @@ namespace plorth
     }
     switch (val->type())
     {
-      case value::type_symbol:
+      case value::type::symbol:
         return exec_sym(ctx, std::static_pointer_cast<symbol>(val));
 
-      case value::type_word:
+      case value::type::word:
         return exec_wrd(ctx, std::static_pointer_cast<word>(val));
 
       default:
@@ -96,7 +96,7 @@ namespace plorth
 
         if (prototype && prototype->property(ctx->runtime(), id, val))
         {
-          if (val && val->is(value::type_quote))
+          if (value::is(val, value::type::quote))
           {
             return std::static_pointer_cast<quote>(val)->call(ctx);
           }
@@ -132,7 +132,7 @@ namespace plorth
     }
 
     // Otherwise it's reference error.
-    ctx->error(error::code_reference, U"Unrecognized word: `" + id + U"'");
+    ctx->error(error::code::reference, U"Unrecognized word: `" + id + U"'");
 
     return false;
   }

--- a/libplorth/src/io-input.cpp
+++ b/libplorth/src/io-input.cpp
@@ -47,11 +47,11 @@ namespace plorth
 
           if (byte == eof)
           {
-            return result_eof;
+            return result::eof;
           }
           else if (!(unichar_size = utf8_sequence_length(byte)))
           {
-            return result_failure;
+            return result::failure;
           }
           buffer.clear();
           buffer.append(1, byte);
@@ -59,13 +59,13 @@ namespace plorth
           {
             if ((byte = std::cin.get()) == eof)
             {
-              return result_failure;
+              return result::failure;
             }
             buffer.append(1, byte);
           }
           if (!utf8_decode_test(buffer, output))
           {
-            return result_failure;
+            return result::failure;
           }
           if (!infinite)
           {
@@ -74,7 +74,7 @@ namespace plorth
           ++read;
         }
 
-        return result_ok;
+        return result::ok;
       }
     };
 
@@ -85,7 +85,7 @@ namespace plorth
       {
         read = 0;
 
-        return result_eof;
+        return result::eof;
       }
     };
   }

--- a/libplorth/src/module.cpp
+++ b/libplorth/src/module.cpp
@@ -35,7 +35,7 @@ namespace plorth
     // Do not import empty paths.
     if (path.empty() || std::all_of(path.begin(), path.end(), unichar_isspace))
     {
-      error(error::code_import, U"Empty import path.");
+      error(error::code::import, U"Empty import path.");
 
       return false;
     }
@@ -49,7 +49,7 @@ namespace plorth
     // First attempt to resolve the module path into actual file system path.
     if (!module_resolve_path(this, path, resolved_path))
     {
-      error(error::code_import, U"No such file or directory: " + path);
+      error(error::code::import, U"No such file or directory: " + path);
 
       return false;
     }
@@ -77,7 +77,7 @@ namespace plorth
     // context.
     for (const auto& property : module->entries())
     {
-      if (property.second && property.second->is(value::type_quote))
+      if (value::is(property.second, value::type::quote))
       {
         m_dictionary.insert(m_runtime->word(
           m_runtime->symbol(property.first),
@@ -88,7 +88,7 @@ namespace plorth
 
     return true;
 #else
-    error(error::code_import, U"Modules have been disabled.");
+    error(error::code::import, U"Modules have been disabled.");
 
     return false;
 #endif
@@ -107,7 +107,7 @@ namespace plorth
 
     if (!is.good())
     {
-      ctx->error(error::code_import, U"Unable to import `" + path + U"'");
+      ctx->error(error::code::import, U"Unable to import `" + path + U"'");
 
       return std::shared_ptr<object>();
     }
@@ -122,7 +122,7 @@ namespace plorth
     if (!utf8_decode_test(raw_source, source))
     {
       ctx->error(
-        error::code_import,
+        error::code::import,
         U"Unable to decode source code into UTF-8."
       );
 
@@ -144,7 +144,7 @@ namespace plorth
       {
         ctx->error(module_ctx->error());
       } else {
-        ctx->error(error::code_import, U"Module import failed.");
+        ctx->error(error::code::import, U"Module import failed.");
       }
 
       return std::shared_ptr<object>();

--- a/libplorth/src/runtime.cpp
+++ b/libplorth/src/runtime.cpp
@@ -140,7 +140,7 @@ namespace plorth
     }
     read = 0;
 
-    return io::input::result_eof;
+    return io::input::result::eof;
   }
 
   void runtime::print(const unistring& str) const

--- a/libplorth/src/value-array.cpp
+++ b/libplorth/src/value-array.cpp
@@ -193,7 +193,7 @@ namespace plorth
   {
     std::shared_ptr<array> ary;
 
-    if (!that || !that->is(type_array))
+    if (!is(that, type::array))
     {
       return false;
     }
@@ -405,7 +405,7 @@ namespace plorth
       if (!size)
       {
         ctx->push(ary);
-        ctx->error(error::code_range, U"Array is empty.");
+        ctx->error(error::code::range, U"Array is empty.");
         return;
       }
 
@@ -796,7 +796,7 @@ namespace plorth
   {
     for (const auto& value : ary)
     {
-      if (value && value->is(value::type_array))
+      if (value::is(value, value::type::array))
       {
         do_flatten(std::static_pointer_cast<array>(value), container);
       } else {
@@ -839,7 +839,7 @@ namespace plorth
   {
     for (const auto& value : ary)
     {
-      if (value && value->is(value::type_array) && depth < limit)
+      if (value::is(value, value::type::array) && depth < limit)
       {
         do_nflatten(
           std::static_pointer_cast<array>(value),
@@ -1136,7 +1136,7 @@ namespace plorth
 
     if (size == 0)
     {
-      ctx->error(error::code_range, U"Cannot reduce empty array.");
+      ctx->error(error::code::range, U"Cannot reduce empty array.");
       return;
     }
 
@@ -1216,7 +1216,7 @@ namespace plorth
       {
         ctx->push_array(nullptr, 0);
       } else {
-        ctx->error(error::code_range, U"Invalid repeat count.");
+        ctx->error(error::code::range, U"Invalid repeat count.");
       }
     }
   }
@@ -1381,7 +1381,7 @@ namespace plorth
 
       if (!size || index < 0 || index >= static_cast<number::int_type>(size))
       {
-        ctx->error(error::code_range, U"Array index out of bounds.");
+        ctx->error(error::code::range, U"Array index out of bounds.");
         return;
       }
 

--- a/libplorth/src/value-boolean.cpp
+++ b/libplorth/src/value-boolean.cpp
@@ -32,7 +32,7 @@ namespace plorth
 
   bool boolean::equals(const std::shared_ptr<class value>& that) const
   {
-    if (!that || !that->is(type_boolean))
+    if (!is(that, type::boolean))
     {
       return false;
     }

--- a/libplorth/src/value-error.cpp
+++ b/libplorth/src/value-error.cpp
@@ -51,28 +51,28 @@ namespace plorth
   {
     switch (code)
     {
-    case error::code_syntax:
+    case error::code::syntax:
       return U"Syntax error";
 
-    case error::code_reference:
+    case error::code::reference:
       return U"Reference error";
 
-    case error::code_type:
+    case error::code::type:
       return U"Type error";
 
-    case error::code_value:
+    case error::code::value:
       return U"Value error";
 
-    case error::code_range:
+    case error::code::range:
       return U"Range error";
 
-    case error::code_import:
+    case error::code::import:
       return U"Import error";
 
-    case error::code_io:
+    case error::code::io:
       return U"I/O error";
 
-    case error::code_unknown:
+    case error::code::unknown:
       return U"Unknown error";
     }
 
@@ -83,7 +83,7 @@ namespace plorth
   {
     std::shared_ptr<error> err;
 
-    if (!that || !that->is(type_error))
+    if (!is(that, type::error))
     {
       return false;
     }
@@ -135,10 +135,12 @@ namespace plorth
   {
     std::shared_ptr<value> err;
 
-    if (ctx->pop(err, value::type_error))
+    if (ctx->pop(err, value::type::error))
     {
       ctx->push(err);
-      ctx->push_int(std::static_pointer_cast<error>(err)->code());
+      ctx->push_int(static_cast<number::int_type>(
+        std::static_pointer_cast<error>(err)->code()
+      ));
     }
   }
 
@@ -160,9 +162,9 @@ namespace plorth
   {
     std::shared_ptr<value> err;
 
-    if (ctx->pop(err, value::type_error))
+    if (ctx->pop(err, value::type::error))
     {
-      const unistring& message = std::static_pointer_cast<error>(err)->message();
+      const auto& message = std::static_pointer_cast<error>(err)->message();
 
       ctx->push(err);
       if (message.empty())
@@ -195,7 +197,7 @@ namespace plorth
   {
     std::shared_ptr<value> err;
 
-    if (ctx->pop(err, value::type_error))
+    if (ctx->pop(err, value::type::error))
     {
       const auto position = std::static_pointer_cast<error>(err)->position();
 
@@ -228,7 +230,7 @@ namespace plorth
   {
     std::shared_ptr<value> err;
 
-    if (ctx->pop(err, value::type_error))
+    if (ctx->pop(err, value::type::error))
     {
       ctx->error(std::static_pointer_cast<error>(err));
     }

--- a/libplorth/src/value-number.cpp
+++ b/libplorth/src/value-number.cpp
@@ -53,7 +53,7 @@ namespace plorth
 
       enum number_type number_type() const
       {
-        return number_type_int;
+        return number_type::integer;
       }
 
       int_type as_int() const
@@ -78,7 +78,7 @@ namespace plorth
 
       enum number_type number_type() const
       {
-        return number_type_real;
+        return number_type::real;
       }
 
       int_type as_int() const
@@ -111,12 +111,12 @@ namespace plorth
   {
     std::shared_ptr<number> num;
 
-    if (!that || !that->is(type_number))
+    if (!value::is(that, type::number))
     {
       return false;
     }
     num = std::static_pointer_cast<number>(that);
-    if (is(number_type_real) || num->is(number_type_real))
+    if (is(number_type::real) || num->is(number_type::real))
     {
       return as_real() == num->as_real();
     } else {
@@ -126,7 +126,7 @@ namespace plorth
 
   unistring number::to_string() const
   {
-    if (is(number_type_real))
+    if (is(number_type::real))
     {
       return to_unistring(as_real());
     } else {
@@ -223,7 +223,7 @@ namespace plorth
     if (ctx->pop_number(num))
     {
       ctx->push(num);
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_boolean(std::isnan(num->as_real()));
       } else {
@@ -252,7 +252,7 @@ namespace plorth
     if (ctx->pop_number(num))
     {
       ctx->push(num);
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_boolean(std::isfinite(num->as_real()));
       } else {
@@ -278,7 +278,7 @@ namespace plorth
 
     if (ctx->pop_number(num) && ctx->pop_quote(quo))
     {
-      number::int_type count = num->as_int();
+      auto count = num->as_int();
 
       if (count < 0)
       {
@@ -313,7 +313,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_real(std::fabs(num->as_real()));
       } else {
@@ -340,7 +340,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_int(std::round(num->as_real()));
       } else {
@@ -367,7 +367,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_int(std::ceil(num->as_real()));
       } else {
@@ -394,7 +394,7 @@ namespace plorth
 
     if (ctx->pop_number(num))
     {
-      if (num->is(number::number_type_real))
+      if (num->is(number::number_type::real))
       {
         ctx->push_int(std::floor(num->as_real()));
       } else {
@@ -423,7 +423,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push(a->as_real() > b->as_real() ? a : b);
       } else {
@@ -452,7 +452,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push(a->as_real() < b->as_real() ? a : b);
       } else {
@@ -483,9 +483,9 @@ namespace plorth
 
     if (ctx->pop_number(c) && ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real)
-          || b->is(number::number_type_real)
-          || c->is(number::number_type_real))
+      if (a->is(number::number_type::real)
+          || b->is(number::number_type::real)
+          || c->is(number::number_type::real))
       {
         const number::real_type min = a->as_real();
         const number::real_type max = b->as_real();
@@ -501,9 +501,9 @@ namespace plorth
         }
         ctx->push_real(number);
       } else {
-        const number::int_type min = a->as_int();
-        const number::int_type max = b->as_int();
-        number::int_type number = c->as_int();
+        const auto min = a->as_int();
+        const auto max = b->as_int();
+        auto number = c->as_int();
 
         if (number > max)
         {
@@ -541,9 +541,9 @@ namespace plorth
 
     if (ctx->pop_number(c) && ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real)
-          || b->is(number::number_type_real)
-          || c->is(number::number_type_real))
+      if (a->is(number::number_type::real)
+          || b->is(number::number_type::real)
+          || c->is(number::number_type::real))
       {
         const number::real_type min = a->as_real();
         const number::real_type max = b->as_real();
@@ -560,7 +560,7 @@ namespace plorth
     }
   }
 
-  template< typename RealOperation, typename IntOperation >
+  template<class RealOperation, class IntOperation>
   static void number_op(
     const std::shared_ptr<context>& ctx,
     const RealOperation& real_op,
@@ -578,8 +578,8 @@ namespace plorth
 
     result = real_op(a->as_real(), b->as_real());
 
-    if (a->is(number::number_type_int) &&
-        b->is(number::number_type_int) &&
+    if (a->is(number::number_type::integer) &&
+        b->is(number::number_type::integer) &&
         std::fabs(result) <= number::int_max)
     {
       // Repeat the operation with full integer precision
@@ -861,7 +861,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push_boolean(a->as_real() < b->as_real());
       } else {
@@ -890,7 +890,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push_boolean(a->as_real() > b->as_real());
       } else {
@@ -919,7 +919,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push_boolean(a->as_real() <= b->as_real());
       } else {
@@ -949,7 +949,7 @@ namespace plorth
 
     if (ctx->pop_number(b) && ctx->pop_number(a))
     {
-      if (a->is(number::number_type_real) || b->is(number::number_type_real))
+      if (a->is(number::number_type::real) || b->is(number::number_type::real))
       {
         ctx->push_boolean(a->as_real() >= b->as_real());
       } else {

--- a/libplorth/src/value-object.cpp
+++ b/libplorth/src/value-object.cpp
@@ -363,7 +363,7 @@ namespace plorth
     std::shared_ptr<object> obj;
     std::shared_ptr<value> slot;
 
-    if (!that || !that->is(type_object))
+    if (!is(that, type::object))
     {
       return false;
     }
@@ -636,10 +636,9 @@ namespace plorth
     }
 
     if (!obj->own_property(U"prototype", prototype)
-        || !prototype
-        || !prototype->is(value::type_object))
+        || !value::is(prototype, value::type::object))
     {
-      ctx->error(error::code_type, U"Object has no prototype.");
+      ctx->error(error::code::type, U"Object has no prototype.");
       return;
     }
 
@@ -648,8 +647,7 @@ namespace plorth
     if (std::static_pointer_cast<object>(prototype)->property(runtime,
                                                               U"constructor",
                                                               constructor)
-        && constructor
-        && constructor->is(value::type_quote))
+        && value::is(constructor, value::type::quote))
     {
       std::static_pointer_cast<quote>(constructor)->call(ctx);
     }
@@ -686,7 +684,7 @@ namespace plorth
         ctx->push(val);
       } else {
         ctx->error(
-          error::code_range,
+          error::code::range,
           U"No such property: `" + id->to_string() + U"'"
         );
       }
@@ -754,7 +752,7 @@ namespace plorth
       if (!obj->has_own_property(name))
       {
         ctx->error(
-          error::code_range,
+          error::code::range,
           U"No such property: `" + name + U"'"
         );
       }

--- a/libplorth/src/value-quote.cpp
+++ b/libplorth/src/value-quote.cpp
@@ -44,7 +44,7 @@ namespace plorth
 
       inline enum quote_type quote_type() const
       {
-        return quote_type_compiled;
+        return quote_type::compiled;
       }
 
       bool call(const std::shared_ptr<context>& ctx) const
@@ -88,8 +88,8 @@ namespace plorth
       {
         std::shared_ptr<compiled_quote> q;
 
-        if (!that->is(type_quote)
-            || !std::static_pointer_cast<quote>(that)->is(quote_type_compiled))
+        if (!value::is(that, type::quote) ||
+            !std::static_pointer_cast<quote>(that)->is(quote_type::compiled))
         {
           return false;
         }
@@ -125,7 +125,7 @@ namespace plorth
 
       inline enum quote_type quote_type() const
       {
-        return quote_type_native;
+        return quote_type::native;
       }
 
       bool call(const std::shared_ptr<context>& ctx) const

--- a/libplorth/src/value-string.cpp
+++ b/libplorth/src/value-string.cpp
@@ -158,7 +158,7 @@ namespace plorth
     const size_type len = length();
     std::shared_ptr<string> str;
 
-    if (!that || !that->is(type_string))
+    if (!is(that, type::string))
     {
       return false;
     }
@@ -1132,7 +1132,7 @@ namespace plorth
       {
         ctx->push_number(str);
       } else {
-        ctx->error(error::code_value, U"Could not convert string to number.");
+        ctx->error(error::code::value, U"Could not convert string to number.");
       }
     }
   }
@@ -1207,7 +1207,7 @@ namespace plorth
       {
         ctx->push_string(nullptr, 0);
       } else {
-        ctx->error(error::code_range, U"Invalid repeat count.");
+        ctx->error(error::code::range, U"Invalid repeat count.");
       }
     }
   }
@@ -1248,7 +1248,7 @@ namespace plorth
 
       if (!length || index < 0 || index >= static_cast<number::int_type>(length))
       {
-        ctx->error(error::code_range, U"String index out of bounds.");
+        ctx->error(error::code::range, U"String index out of bounds.");
         return;
       }
 
@@ -1280,7 +1280,7 @@ namespace plorth
 
       if (!length)
       {
-        ctx->error(error::code_value, U"Cannot construct empty symbol.");
+        ctx->error(error::code::value, U"Cannot construct empty symbol.");
         return;
       }
       for (string::size_type i = 0; i < length; ++i)
@@ -1288,7 +1288,7 @@ namespace plorth
         if (!unichar_isword(str->at(i)))
         {
           ctx->error(
-            error::code_value,
+            error::code::value,
             U"Cannot convert " + str->to_source() + U" into symbol."
           );
           return;

--- a/libplorth/src/value-symbol.cpp
+++ b/libplorth/src/value-symbol.cpp
@@ -59,7 +59,7 @@ namespace plorth
 
   bool symbol::equals(const std::shared_ptr<value>& that) const
   {
-    if (that && that->is(type_symbol))
+    if (is(that, type::symbol))
     {
       return !m_id.compare(std::static_pointer_cast<symbol>(that)->m_id);
     } else {
@@ -124,7 +124,7 @@ namespace plorth
   {
     std::shared_ptr<value> sym;
 
-    if (ctx->pop(sym, value::type_symbol))
+    if (ctx->pop(sym, value::type::symbol))
     {
       const auto position = std::static_pointer_cast<symbol>(sym)->position();
 

--- a/libplorth/src/value-word.cpp
+++ b/libplorth/src/value-word.cpp
@@ -37,7 +37,7 @@ namespace plorth
   {
     std::shared_ptr<word> w;
 
-    if (!that || !that->is(type_word))
+    if (!is(that, type::word))
     {
       return false;
     }

--- a/libplorth/src/value.cpp
+++ b/libplorth/src/value.cpp
@@ -36,78 +36,80 @@ namespace plorth
   {
     switch (type)
     {
-    case value::type_null:
+    case type::null:
       return U"null";
 
-    case value::type_boolean:
+    case type::boolean:
       return U"boolean";
 
-    case value::type_number:
+    case type::number:
       return U"number";
 
-    case value::type_string:
+    case type::string:
       return U"string";
 
-    case value::type_array:
+    case type::array:
       return U"array";
 
-    case value::type_object:
+    case type::object:
       return U"object";
 
-    case value::type_symbol:
+    case type::symbol:
       return U"symbol";
 
-    case value::type_quote:
+    case type::quote:
       return U"quote";
 
-    case value::type_word:
+    case type::word:
       return U"word";
 
-    case value::type_error:
+    case type::error:
       return U"error";
     }
 
     return U"unknown";
   }
 
-  std::shared_ptr<object> value::prototype(const std::shared_ptr<class runtime>& runtime) const
+  std::shared_ptr<object> value::prototype(
+    const std::shared_ptr<class runtime>& runtime
+  ) const
   {
     switch (type())
     {
-    case type_null:
+    case type::null:
       return runtime->object_prototype();
 
-    case type_boolean:
+    case type::boolean:
       return runtime->boolean_prototype();
 
-    case type_number:
+    case type::number:
       return runtime->number_prototype();
 
-    case type_string:
+    case type::string:
       return runtime->string_prototype();
 
-    case type_array:
+    case type::array:
       return runtime->array_prototype();
 
-    case type_symbol:
+    case type::symbol:
       return runtime->symbol_prototype();
 
-    case type_quote:
+    case type::quote:
       return runtime->quote_prototype();
 
-    case type_word:
+    case type::word:
       return runtime->word_prototype();
 
-    case type_error:
+    case type::error:
       return runtime->error_prototype();
 
-    case type_object:
+    case type::object:
       {
         std::shared_ptr<value> slot;
 
         if (static_cast<const object*>(this)->own_property(U"__proto__", slot))
         {
-          if (slot && slot->is(type_object))
+          if (is(slot, type::object))
           {
             return std::static_pointer_cast<object>(slot);
           } else {

--- a/webassembly/CMakeLists.txt
+++ b/webassembly/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
-PROJECT(plorth-webassembly C CXX)
+PROJECT(plorth-webassembly CXX)
 
 IF(NOT DEFINED ENV{EMSCRIPTEN})
   MESSAGE(FATAL_ERROR "Emscripten environment variable wasn't found.")


### PR DESCRIPTION
Hey, we are using C++11! Why not convert plain old enums into enum classes instead to avoid accidental conversions and to get properly scoped enumeration names?