### PR TITLE
Get rid of unnecessary type definitions and stream operators

### DIFF
--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -53,14 +53,14 @@ static bool flag_test_syntax = false;
 static bool flag_fork = false;
 static std::string inline_script;
 #if PLORTH_ENABLE_MODULES
-static std::unordered_set<unistring> imported_modules;
+static std::unordered_set<std::u32string> imported_modules;
 #endif
 
 static void scan_arguments(const std::shared_ptr<runtime>&, int, char**);
 static inline bool is_console_interactive();
 static void compile_and_run(const std::shared_ptr<context>&,
                             const std::string&,
-                            const unistring&);
+                            const std::u32string&);
 static void handle_error(const std::shared_ptr<context>&);
 
 namespace plorth
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
 
   if (script_filename)
   {
-    const unistring decoded_script_filename = utf8_decode(script_filename);
+    const auto decoded_script_filename = utf8_decode(script_filename);
     std::ifstream is(script_filename, std::ios_base::in);
 
     if (is.good())
@@ -243,7 +243,7 @@ static void scan_arguments(const std::shared_ptr<class runtime>& runtime,
       case 'r':
         if (offset < argc)
         {
-          unistring module_path;
+          std::u32string module_path;
 
           if (!utf8_decode_test(argv[offset++], module_path))
           {
@@ -315,9 +315,9 @@ static void handle_error(const std::shared_ptr<context>& ctx)
 
 static void compile_and_run(const std::shared_ptr<context>& ctx,
                             const std::string& input,
-                            const unistring& filename)
+                            const std::u32string& filename)
 {
-  unistring source;
+  std::u32string source;
   std::shared_ptr<quote> script;
 
   if (!utf8_decode_test(input, source))

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -305,7 +305,7 @@ static void handle_error(const std::shared_ptr<context>& ctx)
     {
       std::cerr << *position << ':';
     }
-    std::cerr << err->code() << " - " << err->message();
+    std::cerr << err->code() << " - " << utf8_encode(err->message());
   } else {
     std::cerr << "Unknown error.";
   }

--- a/cli/src/repl.cpp
+++ b/cli/src/repl.cpp
@@ -38,7 +38,7 @@ namespace plorth
     void repl_loop(const std::shared_ptr<context>& ctx)
     {
       int line_counter = 0;
-      unistring source;
+      std::u32string source;
       std::stack<char32_t> open_braces;
       char prompt[BUFSIZ];
 

--- a/gui/src/context.cpp
+++ b/gui/src/context.cpp
@@ -39,9 +39,11 @@ namespace plorth
         explicit custom_output(Context::text_written_signal signal)
           : m_signal(signal) {}
 
-        void write(const unistring& text)
+        void write(const std::u32string& text)
         {
-          m_signal.emit(utils::string_convert<Glib::ustring, unistring>(text));
+          m_signal.emit(utils::string_convert<Glib::ustring, std::u32string>(
+            text
+          ));
         }
 
       private:
@@ -70,8 +72,8 @@ namespace plorth
                           int line)
     {
       auto script = m_context->compile(
-        utils::string_convert<unistring, Glib::ustring>(source_code),
-        utils::string_convert<unistring, Glib::ustring>(file),
+        utils::string_convert<std::u32string, Glib::ustring>(source_code),
+        utils::string_convert<std::u32string, Glib::ustring>(file),
         line
       );
 

--- a/gui/src/dictionary-display.cpp
+++ b/gui/src/dictionary-display.cpp
@@ -74,10 +74,10 @@ namespace plorth
         const auto& symbol = word->symbol();
         const auto& quote = word->quote();
 
-        row[symbol_column] = utils::string_convert<Glib::ustring, unistring>(
+        row[symbol_column] = utils::string_convert<Glib::ustring, std::u32string>(
           symbol ? symbol->to_string() : U""
         );
-        row[quote_column] = utils::string_convert<Glib::ustring, unistring>(
+        row[quote_column] = utils::string_convert<Glib::ustring, std::u32string>(
           quote ? quote->to_string() : U"(null)"
         );
       }

--- a/gui/src/stack-display.cpp
+++ b/gui/src/stack-display.cpp
@@ -69,7 +69,7 @@ namespace plorth
         auto row = *(m_tree_model->append());
 
         row[index_column] = ++index;
-        row[value_column] = utils::string_convert<Glib::ustring, unistring>(
+        row[value_column] = utils::string_convert<Glib::ustring, std::u32string>(
           value ? value->to_source() : U"null"
         );
       }

--- a/gui/src/window.cpp
+++ b/gui/src/window.cpp
@@ -113,7 +113,7 @@ namespace plorth
       if (error)
       {
         m_line_display.add_line(
-          utils::string_convert<Glib::ustring, unistring>(
+          utils::string_convert<Glib::ustring, std::u32string>(
             error->to_string()
           ) + '\n',
           LineDisplay::LINE_TYPE_ERROR

--- a/libplorth/include/plorth/context.hpp
+++ b/libplorth/include/plorth/context.hpp
@@ -90,7 +90,7 @@ namespace plorth
      *                 occurred
      */
     void error(enum error::code code,
-               const unistring& message,
+               const std::u32string& message,
                const struct position* position = nullptr);
 
     /**
@@ -130,8 +130,8 @@ namespace plorth
      * \return         Reference the quote that was compiled from given source,
      *                 or null reference if syntax error was encountered.
      */
-    std::shared_ptr<quote> compile(const unistring& source,
-                                   const unistring& filename = U"",
+    std::shared_ptr<quote> compile(const std::u32string& source,
+                                   const std::u32string& filename = U"",
                                    int line = 1,
                                    int column = 1);
 
@@ -143,7 +143,7 @@ namespace plorth
      * \return     Boolean flag telling whether the import was successfull or
      *             whether some kind of error was occurred.
      */
-    bool import(const unistring& path);
+    bool import(const std::u32string& path);
 
     /**
      * Provides direct access to the data stack.
@@ -217,12 +217,12 @@ namespace plorth
      * Pushes either integer or real number into stack, based on the given text
      * input which is parsed into a number.
      */
-    void push_number(const unistring& value);
+    void push_number(const std::u32string& value);
 
     /**
      * Pushes string value into the data stack.
      */
-    void push_string(const unistring& value);
+    void push_string(const std::u32string& value);
 
     /**
      * Constructs string value from given array of Unicode code points and
@@ -252,7 +252,7 @@ namespace plorth
      * Constructs symbol from given identifier and pushes it onto the data
      * stack.
      */
-    void push_symbol(const unistring& id);
+    void push_symbol(const std::u32string& id);
 
     /**
      * Constructs quote from given sequence of values and pushes it onto the
@@ -402,7 +402,7 @@ namespace plorth
      * Returns optional filename of the context, when the context is executed
      * as module.
      */
-    inline const unistring& filename() const
+    inline const std::u32string& filename() const
     {
       return m_filename;
     }
@@ -411,7 +411,7 @@ namespace plorth
      * Sets optional filename of the context, when the context is executed as
      * module.
      */
-    inline void filename(const unistring& fn)
+    inline void filename(const std::u32string& fn)
     {
       m_filename = fn;
     }
@@ -454,7 +454,7 @@ namespace plorth
     class dictionary m_dictionary;
 #if PLORTH_ENABLE_MODULES
     /** Optional filename of the context, when executed as module. */
-    unistring m_filename;
+    std::u32string m_filename;
 #endif
     /** Current position in source code. */
     struct position m_position;

--- a/libplorth/include/plorth/dictionary.hpp
+++ b/libplorth/include/plorth/dictionary.hpp
@@ -42,7 +42,7 @@ namespace plorth
   public:
     using value_type = std::shared_ptr<word>;
     /** Underlying container type. */
-    using container_type = std::unordered_map<unistring, value_type>;
+    using container_type = std::unordered_map<std::u32string, value_type>;
     using size_type = container_type::size_type;
 
     /**
@@ -85,7 +85,7 @@ namespace plorth
      * string. If no such word is found from the dictionary, null reference
      * will be returned instead.
      */
-    value_type find(const unistring& id) const;
+    value_type find(const std::u32string& id) const;
 
     /**
      * Inserts given word into the dictionary. Existing words with identical

--- a/libplorth/include/plorth/io-input.hpp
+++ b/libplorth/include/plorth/io-input.hpp
@@ -78,7 +78,7 @@ namespace plorth
        */
       virtual result read(
         size_type size,
-        unistring& output,
+        std::u32string& output,
         size_type& read
       ) = 0;
     };

--- a/libplorth/include/plorth/io-output.hpp
+++ b/libplorth/include/plorth/io-output.hpp
@@ -56,7 +56,7 @@ namespace plorth
        *
        * \param str String to write into the output.
        */
-      virtual void write(const unistring& str) = 0;
+      virtual void write(const std::u32string& str) = 0;
     };
   }
 }

--- a/libplorth/include/plorth/position.hpp
+++ b/libplorth/include/plorth/position.hpp
@@ -35,7 +35,7 @@ namespace plorth
    */
   struct position
   {
-    unistring filename;
+    std::u32string filename;
     int line;
     int column;
   };

--- a/libplorth/include/plorth/runtime.hpp
+++ b/libplorth/include/plorth/runtime.hpp
@@ -44,12 +44,12 @@ namespace plorth
       std::pair<const char32_t*, quote::callback>
     >;
     using module_container = std::unordered_map<
-      unistring,
+      std::u32string,
       std::shared_ptr<class object>
     >;
 #if PLORTH_ENABLE_SYMBOL_CACHE
     using symbol_cache = std::unordered_map<
-      unistring,
+      std::u32string,
       std::shared_ptr<class symbol>
     >;
 #endif
@@ -135,7 +135,7 @@ namespace plorth
      * Returns container for command line arguments provided for the
      * interpreter.
      */
-    inline std::vector<unistring>& arguments()
+    inline std::vector<std::u32string>& arguments()
     {
       return m_arguments;
     }
@@ -144,7 +144,7 @@ namespace plorth
      * Returns container for command line arguments provided for the
      * interpreter.
      */
-    inline const std::vector<unistring>& arguments() const
+    inline const std::vector<std::u32string>& arguments() const
     {
       return m_arguments;
     }
@@ -152,7 +152,7 @@ namespace plorth
     /**
      * Returns container for file system paths where modules are searched from.
      */
-    inline std::vector<unistring>& module_paths()
+    inline std::vector<std::u32string>& module_paths()
     {
       return m_module_paths;
     }
@@ -160,7 +160,7 @@ namespace plorth
     /**
      * Returns container for file system paths where modules are searched from.
      */
-    inline const std::vector<unistring>& module_paths() const
+    inline const std::vector<std::u32string>& module_paths() const
     {
       return m_module_paths;
     }
@@ -194,14 +194,14 @@ namespace plorth
      */
     io::input::result read(
       io::input::size_type size,
-      unistring& output,
+      std::u32string& output,
       io::input::size_type& read
     );
 
     /**
      * Outputs given Unicode string into the output of the interpreter.
      */
-    void print(const unistring& str) const;
+    void print(const std::u32string& str) const;
 
     /**
      * Outputs system specific new line into the output of the interpreter.
@@ -212,7 +212,7 @@ namespace plorth
      * Outputs given Unicode string and system specific new line into the
      * output of the interpreter.
      */
-    void println(const unistring& str) const;
+    void println(const std::u32string& str) const;
 
     /**
      * Constructs integer number from given value.
@@ -237,7 +237,7 @@ namespace plorth
      * \param value Value of the number as text.
      * \return      Reference to the created number value.
      */
-    std::shared_ptr<class number> number(const unistring& value);
+    std::shared_ptr<class number> number(const std::u32string& value);
 
     /**
      * Constructs array value from given elements.
@@ -265,7 +265,7 @@ namespace plorth
      * \param input Unicode string to construct string value from.
      * \return      Reference to the created string value.
      */
-    std::shared_ptr<class string> string(const unistring& input);
+    std::shared_ptr<class string> string(const std::u32string& input);
 
     /**
      * Constructs string value from given pointer of Unicode code points.
@@ -286,7 +286,7 @@ namespace plorth
      * \return         Reference to the created symbol.
      */
     std::shared_ptr<class symbol> symbol(
-      const unistring& id,
+      const std::u32string& id,
       const struct position* position = nullptr
     );
 
@@ -306,7 +306,7 @@ namespace plorth
      * Constructs word from given string and quote.
      */
     std::shared_ptr<class word> word(
-      const unistring& id,
+      const std::u32string& id,
       const std::shared_ptr<class quote>& quote
     );
 
@@ -466,9 +466,9 @@ namespace plorth
     /** Prototype for words. */
     std::shared_ptr<class object> m_word_prototype;
     /** List of command line arguments given for the interpreter. */
-    std::vector<unistring> m_arguments;
+    std::vector<std::u32string> m_arguments;
     /** List of file system paths where to look modules from. */
-    std::vector<unistring> m_module_paths;
+    std::vector<std::u32string> m_module_paths;
     /** Container for already imported modules. */
     module_container m_imported_modules;
 #if PLORTH_ENABLE_SYMBOL_CACHE

--- a/libplorth/include/plorth/unicode.hpp
+++ b/libplorth/include/plorth/unicode.hpp
@@ -36,19 +36,6 @@
 namespace plorth
 {
   /**
-   * Decodes Unicode string into UTF-8 and outputs it into given byte stream.
-   */
-  std::ostream& operator<<(std::ostream&, const std::u32string&);
-
-#if defined(__EMSCRIPTEN__)
-  /**
-   * Decodes Unicode string into UTF-32LE and outputs it into given wide char
-   * stream.
-   */
-  std::wostream& operator<<(std::wostream&, const std::u32string&);
-#endif
-
-  /**
    * Decodes UTF-8 encoded byte string into Unicode string. Encountered encoding
    * errors are ignored.
    */

--- a/libplorth/include/plorth/unicode.hpp
+++ b/libplorth/include/plorth/unicode.hpp
@@ -35,95 +35,92 @@
 
 namespace plorth
 {
-  using unichar = char32_t;
-  using unistring = std::u32string;
-
   /**
    * Decodes Unicode string into UTF-8 and outputs it into given byte stream.
    */
-  std::ostream& operator<<(std::ostream&, const unistring&);
+  std::ostream& operator<<(std::ostream&, const std::u32string&);
 
 #if defined(__EMSCRIPTEN__)
   /**
    * Decodes Unicode string into UTF-32LE and outputs it into given wide char
    * stream.
    */
-  std::wostream& operator<<(std::wostream&, const unistring&);
+  std::wostream& operator<<(std::wostream&, const std::u32string&);
 #endif
 
   /**
    * Decodes UTF-8 encoded byte string into Unicode string. Encountered encoding
    * errors are ignored.
    */
-  unistring utf8_decode(const std::string&);
+  std::u32string utf8_decode(const std::string&);
 
   /**
    * Decodes UTF-8 encoded byte string into Unicode string with validation.
    */
-  bool utf8_decode_test(const std::string&, unistring&);
+  bool utf8_decode_test(const std::string&, std::u32string&);
 
   /**
    * Encodes Unicode string into UTF-8 encoded byte string.
    */
-  std::string utf8_encode(const unistring&);
+  std::string utf8_encode(const std::u32string&);
 
 #if defined(__EMSCRIPTEN__)
   /**
    * Decodes UTF-32LE encoded wide character string into Unicode string.
    * Encountered encoding errors are ignored.
    */
-  unistring utf32le_decode(const std::wstring&);
+  std::u32string utf32le_decode(const std::wstring&);
 
   /**
    * Encodes Unicode string into UTF-32LE encoded wide character string.
    */
-  std::wstring utf32le_encode(const unistring&);
+  std::wstring utf32le_encode(const std::u32string&);
 #endif
 
   /**
    * Determines whether given character is valid Unicode code point.
    */
-  bool unichar_validate(unichar);
+  bool unicode_validate(char32_t);
 
   /**
    * Determines whether a character is a control character.
    */
-  bool unichar_iscntrl(unichar);
+  bool unicode_iscntrl(char32_t);
 
   /**
    * Determines whether a character is printable and not a space.
    */
-  bool unichar_isgraph(unichar);
+  bool unicode_isgraph(char32_t);
 
   /**
    * Determines whether a character is whitespace.
    */
-  bool unichar_isspace(unichar);
+  bool unicode_isspace(char32_t);
 
   /**
    * Determines whether a character is upper case.
    */
-  bool unichar_isupper(unichar);
+  bool unicode_isupper(char32_t);
 
   /**
    * Determines whether a character is lower case.
    */
-  bool unichar_islower(unichar);
+  bool unicode_islower(char32_t);
 
   /**
    * Determines whether a character can be part of Plorth word.
    */
-  bool unichar_isword(unichar);
+  bool unicode_isword(char32_t);
 
   /**
    * Converts given Unicode character into upper case.
    */
-  unichar unichar_toupper(unichar);
+  char32_t unicode_toupper(char32_t);
 
   /**
    * Converts given Unicode character into lower case.
    */
-  unichar unichar_tolower(unichar);
+  char32_t unicode_tolower(char32_t);
 
   /**
    * Attempts to determine length (in bytes) of UTF-8 sequence which begins

--- a/libplorth/include/plorth/value-array.hpp
+++ b/libplorth/include/plorth/value-array.hpp
@@ -63,8 +63,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
   };
 
   /**

--- a/libplorth/include/plorth/value-boolean.hpp
+++ b/libplorth/include/plorth/value-boolean.hpp
@@ -46,8 +46,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
 
   private:
     const bool m_value;

--- a/libplorth/include/plorth/value-error.hpp
+++ b/libplorth/include/plorth/value-error.hpp
@@ -64,7 +64,7 @@ namespace plorth
      */
     explicit error(
       enum code code,
-      const unistring& message,
+      const std::u32string& message,
       const struct position* position = nullptr
     );
 
@@ -78,14 +78,14 @@ namespace plorth
     /**
      * Returns textual description of the error code.
      */
-    unistring code_description() const;
+    std::u32string code_description() const;
 
     /**
      * Returns textual description of given error code.
      */
-    static unistring code_description(enum code code);
+    static std::u32string code_description(enum code code);
 
-    inline const unistring& message() const
+    inline const std::u32string& message() const
     {
       return m_message;
     }
@@ -105,14 +105,14 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
 
   private:
     /** Error code. */
     const enum code m_code;
     /** Textual description of the error. */
-    const unistring m_message;
+    const std::u32string m_message;
     /** Optional position in source code. */
     struct position* m_position;
   };

--- a/libplorth/include/plorth/value-number.hpp
+++ b/libplorth/include/plorth/value-number.hpp
@@ -83,8 +83,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
   };
 }
 

--- a/libplorth/include/plorth/value-object.hpp
+++ b/libplorth/include/plorth/value-object.hpp
@@ -43,7 +43,7 @@ namespace plorth
   {
   public:
     using size_type = std::size_t;
-    using key_type = unistring;
+    using key_type = std::u32string;
     using mapped_type = std::shared_ptr<value>;
     using value_type = std::pair<key_type, mapped_type>;
 
@@ -132,8 +132,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
   };
 }
 

--- a/libplorth/include/plorth/value-quote.hpp
+++ b/libplorth/include/plorth/value-quote.hpp
@@ -78,7 +78,7 @@ namespace plorth
       return type::quote;
     }
 
-    unistring to_source() const;
+    std::u32string to_source() const;
   };
 }
 

--- a/libplorth/include/plorth/value-string.hpp
+++ b/libplorth/include/plorth/value-string.hpp
@@ -36,7 +36,7 @@ namespace plorth
   {
   public:
     using size_type = std::size_t;
-    using value_type = unichar;
+    using value_type = char32_t;
     using pointer = value_type*;
     using const_pointer = const value_type*;
     class iterator;
@@ -65,8 +65,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<class value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
   };
 
   /**
@@ -76,7 +76,7 @@ namespace plorth
   {
   public:
     using difference_type = int;
-    using value_type = unichar;
+    using value_type = char32_t;
     using pointer = value_type*;
     using reference = value_type&;
     using iterator_category = std::forward_iterator_tag;

--- a/libplorth/include/plorth/value-symbol.hpp
+++ b/libplorth/include/plorth/value-symbol.hpp
@@ -47,7 +47,7 @@ namespace plorth
      * \param position Optional position in source code where the symbol was
      *                 encountered.
      */
-    explicit symbol(const unistring& id,
+    explicit symbol(const std::u32string& id,
                     const struct position* position = nullptr);
 
     /**
@@ -58,7 +58,7 @@ namespace plorth
     /**
      * Returns string which acts as identifier for the symbol.
      */
-    inline const unistring& id() const
+    inline const std::u32string& id() const
     {
       return m_id;
     }
@@ -84,12 +84,12 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
 
   private:
     /** Identifier of the symbol. */
-    const unistring m_id;
+    const std::u32string m_id;
     /** Position of the symbol in source code. */
     struct position* m_position;
     /** Cached hash code of the symbol. */

--- a/libplorth/include/plorth/value-word.hpp
+++ b/libplorth/include/plorth/value-word.hpp
@@ -68,8 +68,8 @@ namespace plorth
     }
 
     bool equals(const std::shared_ptr<value>& that) const;
-    unistring to_string() const;
-    unistring to_source() const;
+    std::u32string to_string() const;
+    std::u32string to_source() const;
 
   private:
     /** Identifier of the word. */

--- a/libplorth/include/plorth/value.hpp
+++ b/libplorth/include/plorth/value.hpp
@@ -75,12 +75,12 @@ namespace plorth
     /**
      * Returns textual description of type of the value.
      */
-    unistring type_description() const;
+    std::u32string type_description() const;
 
     /**
      * Returns textual description of given value type.
      */
-    static unistring type_description(enum type type);
+    static std::u32string type_description(enum type type);
 
     /**
      * Tests whether given value is of given type.
@@ -146,13 +146,13 @@ namespace plorth
     /**
      * Constructs string representation of the value.
      */
-    virtual unistring to_string() const = 0;
+    virtual std::u32string to_string() const = 0;
 
     /**
      * Constructs a string that resembles as accurately as possible what this
      * value would look like in source code.
      */
-    virtual unistring to_source() const = 0;
+    virtual std::u32string to_source() const = 0;
   };
 
   bool operator==(const std::shared_ptr<value>&, const std::shared_ptr<value>&);

--- a/libplorth/src/compiler.cpp
+++ b/libplorth/src/compiler.cpp
@@ -32,8 +32,8 @@ namespace plorth
     class compiler
     {
     public:
-      explicit compiler(const unistring& source,
-                        const unistring& filename,
+      explicit compiler(const std::u32string& source,
+                        const std::u32string& filename,
                         int line,
                         int column)
         : m_pos(std::begin(source))
@@ -66,9 +66,9 @@ namespace plorth
        * Advances to the next character in source code and returns the current
        * one.
        */
-      inline unichar read()
+      inline char32_t read()
       {
-        const unichar result = *m_pos++;
+        const auto result = *m_pos++;
 
         if (result == '\n')
         {
@@ -85,7 +85,7 @@ namespace plorth
        * Returns next character to be read from the source code without
        * advancing any further.
        */
-      inline unichar peek() const
+      inline char32_t peek() const
       {
         return *m_pos;
       }
@@ -94,7 +94,7 @@ namespace plorth
        * Returns true if next character to be read from the source code equals
        * with one given as argument.
        */
-      inline bool peek(unichar expected) const
+      inline bool peek(char32_t expected) const
       {
         return !eof() && peek() == expected;
       }
@@ -103,7 +103,7 @@ namespace plorth
        * Returns true if next character to be read from the source code matches
        * with given callback function.
        */
-      inline bool peek(bool (*callback)(unichar)) const
+      inline bool peek(bool (*callback)(char32_t)) const
       {
         return !eof() && callback(peek());
       }
@@ -112,7 +112,7 @@ namespace plorth
        * Returns true and advances to next character if next character to be
        * read from the source code equals with one given as argument.
        */
-      inline bool peek_read(unichar expected)
+      inline bool peek_read(char32_t expected)
       {
         if (peek(expected))
         {
@@ -129,7 +129,7 @@ namespace plorth
        * read from the source code equals with one given as argument. Current
        * character will be stored into given slot.
        */
-      inline bool peek_read(unichar expected, unichar& slot)
+      inline bool peek_read(char32_t expected, char32_t& slot)
       {
         if (peek(expected))
         {
@@ -204,7 +204,7 @@ namespace plorth
       std::shared_ptr<symbol> compile_symbol(context* ctx)
       {
         struct position position;
-        unistring buffer;
+        std::u32string buffer;
 
         if (skip_whitespace())
         {
@@ -219,7 +219,7 @@ namespace plorth
 
         position = m_position;
 
-        if (!unichar_isword(peek()))
+        if (!unicode_isword(peek()))
         {
           ctx->error(
             error::code::syntax,
@@ -231,7 +231,7 @@ namespace plorth
         }
 
         buffer.append(1, read());
-        while (peek(unichar_isword))
+        while (peek(unicode_isword))
         {
           buffer.append(1, read());
         }
@@ -365,8 +365,8 @@ namespace plorth
       std::shared_ptr<string> compile_string(context* ctx)
       {
         struct position position;
-        unichar separator;
-        unistring buffer;
+        char32_t separator;
+        std::u32string buffer;
 
         if (skip_whitespace())
         {
@@ -398,7 +398,7 @@ namespace plorth
           {
             ctx->error(
               error::code::syntax,
-              unistring(U"Unterminated string; Missing `") + separator + U"'",
+              std::u32string(U"Unterminated string; Missing `") + separator + U"'",
               &position
             );
 
@@ -592,7 +592,7 @@ namespace plorth
         return ctx->runtime()->object(properties);
       }
 
-      bool compile_escape_sequence(context* ctx, unistring& buffer)
+      bool compile_escape_sequence(context* ctx, std::u32string& buffer)
       {
         struct position position;
 
@@ -640,7 +640,7 @@ namespace plorth
 
         case 'u':
           {
-            unichar result = 0;
+            char32_t result = 0;
 
             for (int i = 0; i < 4; ++i)
             {
@@ -677,7 +677,7 @@ namespace plorth
               }
             }
 
-            if (!unichar_validate(result))
+            if (!unicode_validate(result))
             {
               ctx->error(
                 error::code::syntax,
@@ -743,16 +743,16 @@ namespace plorth
 
     private:
       /** Current position in source code. */
-      unistring::const_iterator m_pos;
+      std::u32string::const_iterator m_pos;
       /** Iterator which marks end of the source code. */
-      const unistring::const_iterator m_end;
+      const std::u32string::const_iterator m_end;
       /** Current source code location information. */
       position m_position;
     };
   }
 
-  std::shared_ptr<quote> context::compile(const unistring& source,
-                                          const unistring& filename,
+  std::shared_ptr<quote> context::compile(const std::u32string& source,
+                                          const std::u32string& filename,
                                           int line,
                                           int column)
   {

--- a/libplorth/src/context.cpp
+++ b/libplorth/src/context.cpp
@@ -43,7 +43,7 @@ namespace plorth
     : m_runtime(runtime) {}
 
   void context::error(enum error::code code,
-                      const unistring& message,
+                      const std::u32string& message,
                       const struct position* position)
   {
     if (!position && (m_position.filename.empty() || m_position.line > 0))
@@ -73,12 +73,12 @@ namespace plorth
     push(m_runtime->number(value));
   }
 
-  void context::push_number(const unistring& value)
+  void context::push_number(const std::u32string& value)
   {
     push(m_runtime->number(value));
   }
 
-  void context::push_string(const unistring& value)
+  void context::push_string(const std::u32string& value)
   {
     push(m_runtime->string(value.c_str(), value.length()));
   }
@@ -105,7 +105,7 @@ namespace plorth
     push(m_runtime->object(properties));
   }
 
-  void context::push_symbol(const unistring& id)
+  void context::push_symbol(const std::u32string& id)
   {
     push(m_runtime->symbol(id));
   }

--- a/libplorth/src/dictionary.cpp
+++ b/libplorth/src/dictionary.cpp
@@ -59,7 +59,7 @@ namespace plorth
     return result;
   }
 
-  dictionary::value_type dictionary::find(const unistring& id) const
+  dictionary::value_type dictionary::find(const std::u32string& id) const
   {
     const auto entry = m_words.find(id);
 

--- a/libplorth/src/globals.cpp
+++ b/libplorth/src/globals.cpp
@@ -1218,7 +1218,7 @@ namespace plorth
                          enum error::code code)
   {
     std::shared_ptr<value> val;
-    unistring message;
+    std::u32string message;
 
     if (!ctx->pop(val))
     {
@@ -1322,7 +1322,7 @@ namespace plorth
    */
   static void w_read(const std::shared_ptr<context>& ctx)
   {
-    unistring output;
+    std::u32string output;
     io::input::size_type read;
     auto result = ctx->runtime()->read(0, output, read);
 
@@ -1360,7 +1360,7 @@ namespace plorth
     if (ctx->pop_number(num))
     {
       const number::int_type amount = num->as_int();
-      unistring output;
+      std::u32string output;
       io::input::size_type read;
       io::input::result result;
 
@@ -1449,11 +1449,11 @@ namespace plorth
     {
       number::int_type c = num->as_int();
 
-      if (!unichar_validate(c))
+      if (!unicode_validate(c))
       {
         ctx->error(error::code::range, U"Invalid Unicode code point.");
       } else {
-        ctx->runtime()->print(unistring(1, static_cast<unichar>(c)));
+        ctx->runtime()->print(std::u32string(1, static_cast<char32_t>(c)));
       }
     }
   }

--- a/libplorth/src/io-input.cpp
+++ b/libplorth/src/io-input.cpp
@@ -32,7 +32,7 @@ namespace plorth
     class standard_input : public io::input
     {
     public:
-      result read(size_type size, unistring& output, size_type& read)
+      result read(size_type size, std::u32string& output, size_type& read)
       {
         const bool infinite = !size;
         const auto eof = std::char_traits<char>::eof();
@@ -43,19 +43,19 @@ namespace plorth
         while (infinite || size > 0)
         {
           auto byte = std::cin.get();
-          std::size_t unichar_size;
+          std::size_t unicode_size;
 
           if (byte == eof)
           {
             return result::eof;
           }
-          else if (!(unichar_size = utf8_sequence_length(byte)))
+          else if (!(unicode_size = utf8_sequence_length(byte)))
           {
             return result::failure;
           }
           buffer.clear();
           buffer.append(1, byte);
-          for (std::size_t i = 1; i < unichar_size; ++i)
+          for (std::size_t i = 1; i < unicode_size; ++i)
           {
             if ((byte = std::cin.get()) == eof)
             {
@@ -81,7 +81,7 @@ namespace plorth
     class dummy_input : public io::input
     {
     public:
-      result read(size_type size, unistring& output, size_type& read)
+      result read(size_type size, std::u32string& output, size_type& read)
       {
         read = 0;
 

--- a/libplorth/src/io-output.cpp
+++ b/libplorth/src/io-output.cpp
@@ -32,13 +32,13 @@ namespace plorth
     class dummy_output : public io::output
     {
     public:
-      void write(const unistring&) {}
+      void write(const std::u32string&) {}
     };
 
     class standard_output : public io::output
     {
     public:
-      void write(const unistring& str)
+      void write(const std::u32string& str)
       {
         const auto bytes = utf8_encode(str);
 

--- a/libplorth/src/module.cpp
+++ b/libplorth/src/module.cpp
@@ -24,16 +24,16 @@ namespace plorth
   static const char* plorth_file_extension = ".plorth";
 
   static std::shared_ptr<object> module_import(context*,
-                                               const unistring&);
+                                               const std::u32string&);
   static bool module_resolve_path(context*,
-                                  const unistring&,
-                                  unistring&);
+                                  const std::u32string&,
+                                  std::u32string&);
 #endif
 
-  bool context::import(const unistring& path)
+  bool context::import(const std::u32string& path)
   {
     // Do not import empty paths.
-    if (path.empty() || std::all_of(path.begin(), path.end(), unichar_isspace))
+    if (path.empty() || std::all_of(path.begin(), path.end(), unicode_isspace))
     {
       error(error::code::import, U"Empty import path.");
 
@@ -41,7 +41,7 @@ namespace plorth
     }
 
 #if PLORTH_ENABLE_MODULES
-    unistring resolved_path;
+    std::u32string resolved_path;
     auto& imported_modules = m_runtime->imported_modules();
     runtime::module_container::iterator entry;
     std::shared_ptr<object> module;
@@ -96,11 +96,11 @@ namespace plorth
 
 #if PLORTH_ENABLE_MODULES
   static std::shared_ptr<object> module_import(context* ctx,
-                                               const unistring& path)
+                                               const std::u32string& path)
   {
     std::ifstream is(utf8_encode(path));
     std::string raw_source;
-    unistring source;
+    std::u32string source;
     std::shared_ptr<quote> compiled_module;
     std::shared_ptr<context> module_ctx;
     std::vector<object::value_type> result;
@@ -159,7 +159,7 @@ namespace plorth
     return ctx->runtime()->object(result);
   }
 
-  static bool is_absolute_path(const unistring& path)
+  static bool is_absolute_path(const std::u32string& path)
   {
     const auto length = path.length();
 
@@ -207,7 +207,7 @@ namespace plorth
    * use it as the path from where to read source code from.
    */
   static bool resolve_into_file(const std::string& path,
-                                unistring& resolved_path)
+                                std::u32string& resolved_path)
   {
     struct ::stat st;
 
@@ -251,8 +251,8 @@ namespace plorth
   }
 
   static bool module_resolve_path(context* ctx,
-                                  const unistring& path,
-                                  unistring& resolved_path)
+                                  const std::u32string& path,
+                                  std::u32string& resolved_path)
   {
     std::string encoded_path = utf8_encode(path);
     char buffer[PATH_MAX];
@@ -289,7 +289,7 @@ namespace plorth
       // Skip empty paths.
       if (directory.empty() || std::all_of(directory.begin(),
                                            directory.end(),
-                                           unichar_isspace))
+                                           unicode_isspace))
       {
         continue;
       }

--- a/libplorth/src/position.cpp
+++ b/libplorth/src/position.cpp
@@ -29,15 +29,20 @@ namespace plorth
 {
   std::ostream& operator<<(std::ostream& os, const position& pos)
   {
+    std::string result;
+
     if (pos.filename.empty())
     {
-      os << "<unknown>";
+      result += "<unknown>";
     } else {
-      os << pos.filename;
+      result += utf8_encode(pos.filename);
     }
     if (pos.line > 0)
     {
-      os << ':' << pos.line << ':' << pos.column;
+      result += ':';
+      result += std::to_string(pos.line);
+      result += ':';
+      result += std::to_string(pos.column);
     }
 
     return os;

--- a/libplorth/src/runtime.cpp
+++ b/libplorth/src/runtime.cpp
@@ -131,7 +131,7 @@ namespace plorth
   }
 
   io::input::result runtime::read(io::input::size_type size,
-                                  unistring& output,
+                                  std::u32string& output,
                                   io::input::size_type& read)
   {
     if (m_input)
@@ -143,7 +143,7 @@ namespace plorth
     return io::input::result::eof;
   }
 
-  void runtime::print(const unistring& str) const
+  void runtime::print(const std::u32string& str) const
   {
     if (m_output)
     {
@@ -154,15 +154,15 @@ namespace plorth
   void runtime::println() const
   {
 #if defined(_WIN32)
-    static const unistring newline = {'\r', '\n'};
+    static const std::u32string newline = {'\r', '\n'};
 #else
-    static const unistring newline = {'\n'};
+    static const std::u32string newline = {'\n'};
 #endif
 
     print(newline);
   }
 
-  void runtime::println(const unistring& str) const
+  void runtime::println(const std::u32string& str) const
   {
     print(str);
     println();

--- a/libplorth/src/unicode.cpp
+++ b/libplorth/src/unicode.cpp
@@ -29,18 +29,18 @@ namespace plorth
 {
   static bool utf8_advance(std::string::const_iterator&,
                            const std::string::const_iterator&,
-                           unichar&);
+                           char32_t&);
 
 #if defined(__EMSCRIPTEN__)
-  static unichar utf32le_decode_char(wchar_t);
-  static wchar_t utf32le_encode_char(unichar);
+  static char32_t utf32le_decode_char(wchar_t);
+  static wchar_t utf32le_encode_char(char32_t);
 #endif
 
-  std::ostream& operator<<(std::ostream& out, const unistring& s)
+  std::ostream& operator<<(std::ostream& out, const std::u32string& s)
   {
     for (const auto& c : s)
     {
-      if (!unichar_validate(c))
+      if (!unicode_validate(c))
       {
         continue;
       }
@@ -71,11 +71,11 @@ namespace plorth
   }
 
 #if defined(__EMSCRIPTEN__)
-  std::wostream& operator<<(std::wostream& out, const unistring& s)
+  std::wostream& operator<<(std::wostream& out, const std::u32string& s)
   {
     for (const auto& c : s)
     {
-      if (!unichar_validate(c))
+      if (!unicode_validate(c))
       {
         continue;
       }
@@ -86,7 +86,7 @@ namespace plorth
   }
 #endif
 
-  bool unichar_validate(unichar c)
+  bool unicode_validate(char32_t c)
   {
     return !(c > 0x10ffff
         || (c & 0xfffe) == 0xfffe
@@ -94,7 +94,7 @@ namespace plorth
         || (c >= 0xfdd0 && c <= 0xfdef));
   }
 
-  std::string utf8_encode(const unistring& input)
+  std::string utf8_encode(const std::u32string& input)
   {
     const auto length = input.length();
     std::string result;
@@ -103,7 +103,7 @@ namespace plorth
     {
       const auto c = input[i];
 
-      if (!unichar_validate(c))
+      if (!unicode_validate(c))
       {
         continue;
       }
@@ -133,15 +133,15 @@ namespace plorth
     return result;
   }
 
-  unistring utf8_decode(const std::string& input)
+  std::u32string utf8_decode(const std::string& input)
   {
     auto it = std::begin(input);
     const auto end = std::end(input);
-    unistring result;
+    std::u32string result;
 
     while (it != end)
     {
-      unichar c;
+      char32_t c;
 
       if (!utf8_advance(it, end, c))
       {
@@ -153,14 +153,14 @@ namespace plorth
     return result;
   }
 
-  bool utf8_decode_test(const std::string& input, unistring& output)
+  bool utf8_decode_test(const std::string& input, std::u32string& output)
   {
     auto it = std::begin(input);
     const auto end = std::end(input);
 
     while (it != end)
     {
-      unichar c;
+      char32_t c;
 
       if (!utf8_advance(it, end, c))
       {
@@ -173,9 +173,9 @@ namespace plorth
   }
 
 #if defined(__EMSCRIPTEN__)
-  unistring utf32le_decode(const std::wstring& input)
+  std::u32string utf32le_decode(const std::wstring& input)
   {
-    unistring output;
+    std::u32string output;
 
     for (const auto& c : input)
     {
@@ -185,13 +185,13 @@ namespace plorth
     return output;
   }
 
-  std::wstring utf32le_encode(const unistring& input)
+  std::wstring utf32le_encode(const std::u32string& input)
   {
     std::wstring output;
 
     for (const auto& c : input)
     {
-      if (!unichar_validate(c))
+      if (!unicode_validate(c))
       {
         continue;
       }
@@ -202,14 +202,14 @@ namespace plorth
     return output;
   }
 
-  static unichar utf32le_decode_char(wchar_t c)
+  static char32_t utf32le_decode_char(wchar_t c)
   {
     const unsigned char* p = reinterpret_cast<const unsigned char*>(&c);
 
-    return static_cast<unichar>(((p[3] * 256 + p[2]) * 256 + p[1]) * 256 + p[0]);
+    return static_cast<char32_t>(((p[3] * 256 + p[2]) * 256 + p[1]) * 256 + p[0]);
   }
 
-  wchar_t utf32le_encode_char(unichar c)
+  wchar_t utf32le_encode_char(char32_t c)
   {
     unsigned char buffer[4];
 
@@ -224,7 +224,7 @@ namespace plorth
 
   static bool utf8_advance(std::string::const_iterator& it,
                            const std::string::const_iterator& end,
-                           unichar& result)
+                           char32_t& result)
   {
     const std::size_t sequence_length = utf8_sequence_length(*it);
 
@@ -309,9 +309,9 @@ namespace plorth
     }
   }
 
-  bool unichar_iscntrl(unichar c)
+  bool unicode_iscntrl(char32_t c)
   {
-    static const unichar cntrl_table[19][2] =
+    static const char32_t cntrl_table[19][2] =
     {
       { 0x0000, 0x001f }, { 0x007f, 0x009f }, { 0x00ad, 0x00ad },
       { 0x0600, 0x0603 }, { 0x06dd, 0x06dd }, { 0x070f, 0x070f },
@@ -333,9 +333,9 @@ namespace plorth
     return false;
   }
 
-  bool unichar_isgraph(unichar c)
+  bool unicode_isgraph(char32_t c)
   {
-    static const unichar graph_table[424][2] =
+    static const char32_t graph_table[424][2] =
     {
       { 0x0021, 0x007e }, { 0x00a1, 0x0241 }, { 0x0250, 0x036f },
       { 0x0374, 0x0375 }, { 0x037a, 0x037a }, { 0x037e, 0x037e },
@@ -492,9 +492,9 @@ namespace plorth
     return false;
   }
 
-  bool unichar_isspace(unichar c)
+  bool unicode_isspace(char32_t c)
   {
-    static const unichar space_table[11][2] =
+    static const char32_t space_table[11][2] =
     {
       { 0x0009, 0x000d }, { 0x0020, 0x0020 },
       { 0x0085, 0x0085 }, { 0x00a0, 0x00a0 },
@@ -515,9 +515,9 @@ namespace plorth
     return false;
   }
 
-  bool unichar_isupper(unichar c)
+  bool unicode_isupper(char32_t c)
   {
-    static const unichar upper_table[476][2] =
+    static const char32_t upper_table[476][2] =
     {
     { 0x0041, 0x005a }, { 0x00c0, 0x00d6 }, { 0x00d8, 0x00de },
     { 0x0100, 0x0100 }, { 0x0102, 0x0102 }, { 0x0104, 0x0104 },
@@ -691,9 +691,9 @@ namespace plorth
     return false;
   }
 
-  bool unichar_islower(unichar c)
+  bool unicode_islower(char32_t c)
   {
-    static const unichar lower_table[480][2] =
+    static const char32_t lower_table[480][2] =
     {
       { 0x0061, 0x007a }, { 0x00aa, 0x00aa }, { 0x00b5, 0x00b5 },
       { 0x00ba, 0x00ba }, { 0x00df, 0x00f6 }, { 0x00f8, 0x00ff },
@@ -868,13 +868,13 @@ namespace plorth
     return false;
   }
 
-  bool unichar_isword(unichar c)
+  bool unicode_isword(char32_t c)
   {
     return c != '(' && c != ')' && c != '[' && c != ']' && c != '{'
-      && c != '}' && c != ':' && c != ';' && c != ',' && unichar_isgraph(c);
+      && c != '}' && c != ':' && c != ';' && c != ',' && unicode_isgraph(c);
   }
 
-  unichar unichar_tolower(unichar cp)
+  char32_t unicode_tolower(char32_t cp)
   {
     if (cp >= 'A' && cp <= 'Z')
     {
@@ -947,7 +947,7 @@ namespace plorth
     return cp;
   }
 
-  unichar unichar_toupper(unichar cp)
+  char32_t unicode_toupper(char32_t cp)
   {
     if (cp >= 'a' && cp <= 'z')
     {

--- a/libplorth/src/unicode.cpp
+++ b/libplorth/src/unicode.cpp
@@ -36,56 +36,6 @@ namespace plorth
   static wchar_t utf32le_encode_char(char32_t);
 #endif
 
-  std::ostream& operator<<(std::ostream& out, const std::u32string& s)
-  {
-    for (const auto& c : s)
-    {
-      if (!unicode_validate(c))
-      {
-        continue;
-      }
-
-      if (c <= 0x7f)
-      {
-        out << static_cast<char>(c);
-      }
-      else if (c <= 0x07ff)
-      {
-        out << static_cast<char>(0xc0 | ((c & 0x7c0) >> 6));
-        out << static_cast<char>(0x80 | (c & 0x3f));
-      }
-      else if (c <= 0xffff)
-      {
-        out << static_cast<char>(0xe0 | ((c & 0xf000)) >> 12);
-        out << static_cast<char>(0x80 | ((c & 0xfc0)) >> 6);
-        out << static_cast<char>(0x80 | (c & 0x3f));
-      } else {
-        out << static_cast<char>(0xf0 | ((c & 0x1c0000) >> 18));
-        out << static_cast<char>(0x80 | ((c & 0x3f000) >> 12));
-        out << static_cast<char>(0x80 | ((c & 0xfc0) >> 6));
-        out << static_cast<char>(0x80 | (c & 0x3f));
-      }
-    }
-
-    return out;
-  }
-
-#if defined(__EMSCRIPTEN__)
-  std::wostream& operator<<(std::wostream& out, const std::u32string& s)
-  {
-    for (const auto& c : s)
-    {
-      if (!unicode_validate(c))
-      {
-        continue;
-      }
-
-      out << utf32le_encode_char(c);
-    }
-    return out;
-  }
-#endif
-
   bool unicode_validate(char32_t c)
   {
     return !(c > 0x10ffff

--- a/libplorth/src/utils.cpp
+++ b/libplorth/src/utils.cpp
@@ -40,13 +40,13 @@ namespace plorth
 #endif
 
   static const char digitmap[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  static const unistring unistring_nan = {'n', 'a', 'n'};
-  static const unistring unistring_inf = {'i', 'n', 'f'};
-  static const unistring unistring_inf_neg = {'-', 'i', 'n', 'f'};
+  static const std::u32string string_nan = {'n', 'a', 'n'};
+  static const std::u32string string_inf = {'i', 'n', 'f'};
+  static const std::u32string string_inf_neg = {'-', 'i', 'n', 'f'};
 
-  unistring json_stringify(const unistring& input)
+  std::u32string json_stringify(const std::u32string& input)
   {
-    unistring result;
+    std::u32string result;
 
     result.reserve(input.length() + 2);
     result.append(1, '"');
@@ -88,14 +88,14 @@ namespace plorth
           break;
 
         default:
-          if (unichar_iscntrl(c))
+          if (unicode_iscntrl(c))
           {
             char buffer[7];
 
             std::snprintf(buffer, 7, "\\u%04x", c);
             for (const char* p = buffer; *p; ++p)
             {
-              result.append(1, static_cast<unichar>(*p));
+              result.append(1, static_cast<char32_t>(*p));
             }
           } else {
             result.append(1, c);
@@ -108,10 +108,10 @@ namespace plorth
     return result;
   }
 
-  bool is_number(const unistring& input)
+  bool is_number(const std::u32string& input)
   {
     const auto length = input.length();
-    unistring::size_type start;
+    std::u32string::size_type start;
     bool dot_seen = false;
     bool exponent_seen = false;
 
@@ -167,11 +167,11 @@ namespace plorth
     return true;
   }
 
-  unistring to_unistring(number::int_type number)
+  std::u32string to_unistring(number::int_type number)
   {
     const bool negative = number < 0;
     uint_type mag = static_cast<uint_type>(negative ? -number : number);
-    unistring result;
+    std::u32string result;
 
     if (mag != 0)
     {
@@ -193,24 +193,24 @@ namespace plorth
     return result;
   }
 
-  unistring to_unistring(number::real_type number)
+  std::u32string to_unistring(number::real_type number)
   {
     char buffer[20];
 
     if (std::isnan(number))
     {
-      return unistring_nan;
+      return string_nan;
     }
     else if (std::isinf(number))
     {
-      return number < 0.0 ? unistring_inf_neg : unistring_inf;
+      return number < 0.0 ? string_inf_neg : string_inf;
     }
     std::snprintf(buffer, sizeof(buffer), "%g", number);
 
     return utf8_decode(buffer);
   }
 
-  number::int_type to_integer(const unistring& input)
+  number::int_type to_integer(const std::u32string& input)
   {
     static const number::int_type div = number::int_max / 10;
     static const number::int_type rem = number::int_max % 10;
@@ -231,7 +231,7 @@ namespace plorth
 
     for (; offset < length; ++offset)
     {
-      const unichar c = input[offset];
+      const auto c = input[offset];
       int digit;
 
       if (!std::isdigit(c))
@@ -249,11 +249,11 @@ namespace plorth
     return sign ? number : -number;
   }
 
-  number::real_type to_real(const unistring& input)
+  number::real_type to_real(const std::u32string& input)
   {
     const auto length = input.length();
     number::real_type number;
-    unistring::size_type offset;
+    std::u32string::size_type offset;
     bool seen_digits = false;
     bool seen_dot = false;
     bool sign;
@@ -264,15 +264,15 @@ namespace plorth
       return false;
     }
 
-    if (!input.compare(unistring_nan))
+    if (!input.compare(string_nan))
     {
       return NAN;
     }
-    else if (!input.compare(unistring_inf))
+    else if (!input.compare(string_inf))
     {
       return INFINITY;
     }
-    else if (!input.compare(unistring_inf_neg))
+    else if (!input.compare(string_inf_neg))
     {
       return -INFINITY;
     }
@@ -339,26 +339,26 @@ namespace plorth
     return number;
   }
 
-  unistring dirname(const unistring& path)
+  std::u32string dirname(const std::u32string& path)
   {
     const auto length = path.length();
-    unistring::size_type index;
+    std::u32string::size_type index;
 
     if (!length)
     {
-      return unistring();
+      return std::u32string();
     }
 
     index = path.find_last_of(PLORTH_FILE_SEPARATOR);
     // No slashes found?
-    if (index == unistring::npos)
+    if (index == std::u32string::npos)
     {
       return U".";
     }
     // Slash is the first character?
     else if (index == 0)
     {
-      return unistring(1, PLORTH_FILE_SEPARATOR);
+      return std::u32string(1, PLORTH_FILE_SEPARATOR);
     }
     // Slash is the last character?
     else if (index == length - 1)

--- a/libplorth/src/utils.hpp
+++ b/libplorth/src/utils.hpp
@@ -36,13 +36,13 @@
 
 namespace plorth
 {
-  unistring json_stringify(const unistring&);
-  number::int_type to_integer(const unistring&);
-  number::real_type to_real(const unistring&);
-  bool is_number(const unistring&);
-  unistring to_unistring(number::int_type);
-  unistring to_unistring(number::real_type);
-  unistring dirname(const unistring&);
+  std::u32string json_stringify(const std::u32string&);
+  number::int_type to_integer(const std::u32string&);
+  number::real_type to_real(const std::u32string&);
+  bool is_number(const std::u32string&);
+  std::u32string to_unistring(number::int_type);
+  std::u32string to_unistring(number::real_type);
+  std::u32string dirname(const std::u32string&);
 }
 
 #endif /* !PLORTH_UTILS_HPP_GUARD */

--- a/libplorth/src/value-array.cpp
+++ b/libplorth/src/value-array.cpp
@@ -216,10 +216,10 @@ namespace plorth
     return true;
   }
 
-  unistring array::to_string() const
+  std::u32string array::to_string() const
   {
     const size_type s = size();
-    unistring result;
+    std::u32string result;
 
     for (size_type i = 0; i < s; ++i)
     {
@@ -239,10 +239,10 @@ namespace plorth
     return result;
   }
 
-  unistring array::to_source() const
+  std::u32string array::to_source() const
   {
     const size_type s = size();
-    unistring result;
+    std::u32string result;
 
     result += '[';
     for (size_type i = 0; i < s; ++i)
@@ -765,7 +765,7 @@ namespace plorth
   {
     std::shared_ptr<array> ary;
     std::shared_ptr<string> separator;
-    unistring result;
+    std::u32string result;
 
     if (!ctx->pop_array(ary) || !ctx->pop_string(separator))
     {

--- a/libplorth/src/value-boolean.cpp
+++ b/libplorth/src/value-boolean.cpp
@@ -40,12 +40,12 @@ namespace plorth
     return m_value == std::static_pointer_cast<boolean>(that)->m_value;
   }
 
-  unistring boolean::to_string() const
+  std::u32string boolean::to_string() const
   {
     return m_value ? U"true" : U"false";
   }
 
-  unistring boolean::to_source() const
+  std::u32string boolean::to_source() const
   {
     return to_string();
   }

--- a/libplorth/src/value-error.cpp
+++ b/libplorth/src/value-error.cpp
@@ -113,7 +113,7 @@ namespace plorth
 
   std::ostream& operator<<(std::ostream& out, enum error::code code)
   {
-    out << error::code_description(code);
+    out << utf8_encode(error::code_description(code));
 
     return out;
   }

--- a/libplorth/src/value-error.cpp
+++ b/libplorth/src/value-error.cpp
@@ -28,7 +28,7 @@
 namespace plorth
 {
   error::error(enum code code,
-               const unistring& message,
+               const std::u32string& message,
                const struct position* position)
     : m_code(code)
     , m_message(message)
@@ -42,12 +42,12 @@ namespace plorth
     }
   }
 
-  unistring error::code_description() const
+  std::u32string error::code_description() const
   {
     return code_description(m_code);
   }
 
-  unistring error::code_description(enum code code)
+  std::u32string error::code_description(enum code code)
   {
     switch (code)
     {
@@ -93,9 +93,9 @@ namespace plorth
     return m_code == err->m_code && !m_message.compare(err->m_message);
   }
 
-  unistring error::to_string() const
+  std::u32string error::to_string() const
   {
-    unistring result;
+    std::u32string result;
 
     result += code_description();
     if (!m_message.empty())
@@ -106,7 +106,7 @@ namespace plorth
     return result;
   }
 
-  unistring error::to_source() const
+  std::u32string error::to_source() const
   {
     return U"<" + to_string() + U">";
   }

--- a/libplorth/src/value-number.cpp
+++ b/libplorth/src/value-number.cpp
@@ -124,7 +124,7 @@ namespace plorth
     }
   }
 
-  unistring number::to_string() const
+  std::u32string number::to_string() const
   {
     if (is(number_type::real))
     {
@@ -134,7 +134,7 @@ namespace plorth
     }
   }
 
-  unistring number::to_source() const
+  std::u32string number::to_source() const
   {
     return to_string();
   }
@@ -173,16 +173,16 @@ namespace plorth
     );
   }
 
-  std::shared_ptr<class number> runtime::number(const unistring& value)
+  std::shared_ptr<class number> runtime::number(const std::u32string& value)
   {
     const auto dot_index = value.find('.');
     const auto exponent_index_lower_case = value.find('e');
     const auto exponent_index_upper_case = value.find('E');
 
     if (
-      dot_index == unistring::npos &&
-      exponent_index_lower_case == unistring::npos &&
-      exponent_index_upper_case == unistring::npos
+      dot_index == std::u32string::npos &&
+      exponent_index_lower_case == std::u32string::npos &&
+      exponent_index_upper_case == std::u32string::npos
     )
     {
       const number::int_type result = to_integer(value);

--- a/libplorth/src/value-object.cpp
+++ b/libplorth/src/value-object.cpp
@@ -388,9 +388,9 @@ namespace plorth
     return true;
   }
 
-  unistring object::to_string() const
+  std::u32string object::to_string() const
   {
-    unistring result;
+    std::u32string result;
     bool first = true;
 
     for (const auto property : entries())
@@ -413,9 +413,9 @@ namespace plorth
     return result;
   }
 
-  unistring object::to_source() const
+  std::u32string object::to_source() const
   {
-    unistring result;
+    std::u32string result;
     bool first = true;
 
     result += '{';
@@ -782,7 +782,7 @@ namespace plorth
     if (ctx->pop_object(a) && ctx->pop_object(b))
     {
       const auto entries = b->entries();
-      std::unordered_map<unistring, std::shared_ptr<value>> properties(
+      std::unordered_map<std::u32string, std::shared_ptr<value>> properties(
         std::begin(entries),
         std::end(entries)
       );

--- a/libplorth/src/value-quote.cpp
+++ b/libplorth/src/value-quote.cpp
@@ -60,9 +60,9 @@ namespace plorth
         return true;
       }
 
-      unistring to_string() const
+      std::u32string to_string() const
       {
-        unistring result;
+        std::u32string result;
         bool first = true;
 
         for (const auto& value : m_values)
@@ -135,7 +135,7 @@ namespace plorth
         return !ctx->error();
       }
 
-      unistring to_string() const
+      std::u32string to_string() const
       {
         return U"\"native quote\"";
       }
@@ -166,7 +166,7 @@ namespace plorth
     );
   }
 
-  unistring quote::to_source() const
+  std::u32string quote::to_source() const
   {
     return U"(" + to_string() + U")";
   }

--- a/libplorth/src/value-string.cpp
+++ b/libplorth/src/value-string.cpp
@@ -38,13 +38,13 @@ namespace plorth
     class simple_string : public string
     {
     public:
-      explicit simple_string(const unichar* chars, size_type length)
+      explicit simple_string(const char32_t* chars, size_type length)
         : m_length(length)
-        , m_chars(m_length > 0 ? new unichar[m_length] : nullptr)
+        , m_chars(m_length > 0 ? new char32_t[m_length] : nullptr)
       {
         if (m_length > 0)
         {
-          std::memcpy(m_chars, chars, sizeof(unichar) * m_length);
+          std::memcpy(m_chars, chars, sizeof(char32_t) * m_length);
         }
       }
 
@@ -68,7 +68,7 @@ namespace plorth
 
     private:
       const size_type m_length;
-      unichar* m_chars;
+      char32_t* m_chars;
     };
 
     class concat_string : public string
@@ -178,10 +178,10 @@ namespace plorth
     return true;
   }
 
-  unistring string::to_string() const
+  std::u32string string::to_string() const
   {
     const size_type len = length();
-    unistring result;
+    std::u32string result;
 
     result.reserve(len);
     for (size_type i = 0; i < len; ++i)
@@ -192,7 +192,7 @@ namespace plorth
     return result;
   }
 
-  unistring string::to_source() const
+  std::u32string string::to_source() const
   {
     return json_stringify(to_string());
   }
@@ -245,7 +245,7 @@ namespace plorth
     return m_index != that.m_index;
   }
 
-  std::shared_ptr<string> runtime::string(const unistring& input)
+  std::shared_ptr<string> runtime::string(const std::u32string& input)
   {
     return string(input.c_str(), input.length());
   }
@@ -283,7 +283,7 @@ namespace plorth
   }
 
   static void str_test(const std::shared_ptr<context>& ctx,
-                       bool (*callback)(unichar))
+                       bool (*callback)(char32_t))
   {
     std::shared_ptr<string> str;
 
@@ -640,7 +640,7 @@ namespace plorth
    */
   static void w_is_space(const std::shared_ptr<context>& ctx)
   {
-    str_test(ctx, unichar_isspace);
+    str_test(ctx, unicode_isspace);
   }
 
   /**
@@ -659,7 +659,7 @@ namespace plorth
    */
   static void w_is_lower_case(const std::shared_ptr<context>& ctx)
   {
-    str_test(ctx, unichar_islower);
+    str_test(ctx, unicode_islower);
   }
 
   /**
@@ -678,7 +678,7 @@ namespace plorth
    */
   static void w_is_upper_case(const std::shared_ptr<context>& ctx)
   {
-    str_test(ctx, unichar_isupper);
+    str_test(ctx, unicode_isupper);
   }
 
   /**
@@ -777,7 +777,7 @@ namespace plorth
 
       for (string::size_type i = 0; i < length; ++i)
       {
-        if (unichar_isspace(str->at(i)))
+        if (unicode_isspace(str->at(i)))
         {
           if (end - begin > 0)
           {
@@ -825,7 +825,7 @@ namespace plorth
 
       for (string::size_type i = 0; i < length; ++i)
       {
-        const unichar c = str->at(i);
+        const auto c = str->at(i);
 
         if (i + 1 < length && c == '\r' && str->at(i + 1) == '\n')
         {
@@ -873,14 +873,14 @@ namespace plorth
   }
 
   static void str_convert(const std::shared_ptr<context>& ctx,
-                          unichar (*callback)(unichar))
+                          char32_t (*callback)(char32_t))
   {
     std::shared_ptr<string> str;
 
     if (ctx->pop_string(str))
     {
       const auto length = str->length();
-      unichar result[length];
+      char32_t result[length];
 
       for (string::size_type i = 0; i < length; ++i)
       {
@@ -904,7 +904,7 @@ namespace plorth
    */
   static void w_upper_case(const std::shared_ptr<context>& ctx)
   {
-    str_convert(ctx, unichar_toupper);
+    str_convert(ctx, unicode_toupper);
   }
 
   /**
@@ -921,16 +921,16 @@ namespace plorth
    */
   static void w_lower_case(const std::shared_ptr<context>& ctx)
   {
-    str_convert(ctx, unichar_tolower);
+    str_convert(ctx, unicode_tolower);
   }
 
-  static inline unichar unichar_swapcase(unichar c)
+  static inline char32_t unicode_swapcase(char32_t c)
   {
-    if (unichar_islower(c))
+    if (unicode_islower(c))
     {
-      return unichar_toupper(c);
+      return unicode_toupper(c);
     } else {
-      return unichar_tolower(c);
+      return unicode_tolower(c);
     }
   }
 
@@ -948,7 +948,7 @@ namespace plorth
    */
   static void w_swap_case(const std::shared_ptr<context>& ctx)
   {
-    str_convert(ctx, unichar_swapcase);
+    str_convert(ctx, unicode_swapcase);
   }
 
   /**
@@ -971,17 +971,17 @@ namespace plorth
     if (ctx->pop_string(str))
     {
       const auto length = str->length();
-      unichar output[length];
+      char32_t output[length];
 
       for (string::size_type i = 0; i < length; ++i)
       {
-        unichar c = str->at(i);
+        auto c = str->at(i);
 
         if (i == 0)
         {
-          c = unichar_toupper(c);
+          c = unicode_toupper(c);
         } else {
-          c = unichar_tolower(c);
+          c = unicode_tolower(c);
         }
         output[i] = c;
       }
@@ -1012,14 +1012,14 @@ namespace plorth
 
       for (i = 0; i < length; ++i)
       {
-        if (!unichar_isspace(str->at(i)))
+        if (!unicode_isspace(str->at(i)))
         {
           break;
         }
       }
       for (j = length; j != 0; --j)
       {
-        if (!unichar_isspace(str->at(j - 1)))
+        if (!unicode_isspace(str->at(j - 1)))
         {
           break;
         }
@@ -1056,7 +1056,7 @@ namespace plorth
 
       for (i = 0; i < length; ++i)
       {
-        if (!unichar_isspace(str->at(i)))
+        if (!unicode_isspace(str->at(i)))
         {
           break;
         }
@@ -1093,7 +1093,7 @@ namespace plorth
 
       for (i = length; i != 0; --i)
       {
-        if (!unichar_isspace(str->at(i - 1)))
+        if (!unicode_isspace(str->at(i - 1)))
         {
           break;
         }
@@ -1126,7 +1126,7 @@ namespace plorth
 
     if (ctx->pop_string(a))
     {
-      const unistring str = a->to_string();
+      const auto str = a->to_string();
 
       if (is_number(str))
       {
@@ -1237,7 +1237,7 @@ namespace plorth
     {
       const auto length = str->length();
       number::int_type index = num->as_int();
-      unichar c;
+      char32_t c;
 
       if (index < 0)
       {
@@ -1285,7 +1285,7 @@ namespace plorth
       }
       for (string::size_type i = 0; i < length; ++i)
       {
-        if (!unichar_isword(str->at(i)))
+        if (!unicode_isword(str->at(i)))
         {
           ctx->error(
             error::code::value,

--- a/libplorth/src/value-symbol.cpp
+++ b/libplorth/src/value-symbol.cpp
@@ -27,7 +27,7 @@
 
 namespace plorth
 {
-  symbol::symbol(const unistring& id, const struct position* position)
+  symbol::symbol(const std::u32string& id, const struct position* position)
     : m_id(id)
     , m_position(position ? new struct position(*position) : nullptr)
     , m_hash(0) {}
@@ -51,7 +51,7 @@ namespace plorth
       std::lock_guard<std::mutex> lock(sym->m_mutex);
 #endif
 
-      h = sym->m_hash = std::hash<unistring>()(sym->m_id);
+      h = sym->m_hash = std::hash<std::u32string>()(sym->m_id);
     }
 
     return h;
@@ -67,17 +67,17 @@ namespace plorth
     }
   }
 
-  unistring symbol::to_string() const
+  std::u32string symbol::to_string() const
   {
     return to_source();
   }
 
-  unistring symbol::to_source() const
+  std::u32string symbol::to_source() const
   {
     return m_id;
   }
 
-  std::shared_ptr<class symbol> runtime::symbol(const unistring& id,
+  std::shared_ptr<class symbol> runtime::symbol(const std::u32string& id,
                                     const struct position* position)
   {
 #if PLORTH_ENABLE_SYMBOL_CACHE

--- a/libplorth/src/value-word.cpp
+++ b/libplorth/src/value-word.cpp
@@ -46,18 +46,18 @@ namespace plorth
     return m_symbol->equals(w->m_symbol) && m_quote->equals(w->m_quote);
   }
 
-  unistring word::to_string() const
+  std::u32string word::to_string() const
   {
     return to_source();
   }
 
-  unistring word::to_source() const
+  std::u32string word::to_source() const
   {
     return U": " + m_symbol->id() + U" " + m_quote->to_string() + U" ;";
   }
 
   std::shared_ptr<word> runtime::word(
-    const unistring& id,
+    const std::u32string& id,
     const std::shared_ptr<class quote>& quote
   )
   {

--- a/libplorth/src/value.cpp
+++ b/libplorth/src/value.cpp
@@ -139,7 +139,7 @@ namespace plorth
 
   std::ostream& operator<<(std::ostream& out, enum value::type type)
   {
-    out << value::type_description(type);
+    out << utf8_encode(value::type_description(type));
 
     return out;
   }
@@ -148,7 +148,7 @@ namespace plorth
   {
     if (value)
     {
-      os << value->to_string();
+      os << utf8_encode(value->to_string());
     } else {
       os << "<no value>";
     }

--- a/libplorth/src/value.cpp
+++ b/libplorth/src/value.cpp
@@ -27,12 +27,12 @@
 
 namespace plorth
 {
-  unistring value::type_description() const
+  std::u32string value::type_description() const
   {
     return type_description(type());
   }
 
-  unistring value::type_description(enum type type)
+  std::u32string value::type_description(enum type type)
   {
     switch (type)
     {


### PR DESCRIPTION
`unichar`, `unistring` and stream operators for these type definitions are not really necessary and could/should be removed from the codebase.